### PR TITLE
Refactor UI tests for new recorder

### DIFF
--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher/CoveragePublisher.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher/CoveragePublisher.java
@@ -14,7 +14,7 @@ import io.jenkins.plugins.coverage.CoveragePublisher.Threshold.GlobalThreshold.G
 /**
  * Coverage Publisher which can be added in the configuration of a FreeStyle Project.
  */
-@Describable("Publish Coverage Report")
+@Describable("Record Code Coverage Results")
 public class CoveragePublisher extends AbstractStep implements PostBuildStep {
 
     private final Control adapter = control("hetero-list-add[adapters]");

--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/MainPanel.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/MainPanel.java
@@ -20,7 +20,7 @@ public class MainPanel extends PageObject {
      * @param parent
      *         job of wanted MainPanel.
      */
-    public MainPanel(Job parent) {
+    public MainPanel(final Job parent) {
         super(parent, parent.url);
     }
 


### PR DESCRIPTION
The UI tests still use the old steps and actions of the [Code Coverage API Plugin](https://github.com/jenkinsci/code-coverage-api-plugin).