### PR TITLE
Add `ignoreParsingErrors` property for freestyle jobs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Shenyu Zheng and other Jenkins contributors
+Copyright (c) 2018-2023 Shenyu Zheng, Ullrich Hafner, Florian Orendi and other Jenkins contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Join the chat at Gitter/Matrix](https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg)](https://gitter.im/jenkinsci/code-coverage-api-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/coverage.svg?color=red)](https://plugins.jenkins.io/coverage)
-[![Jenkins](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/master/)
+[![Jenkins](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/main/)
 [![GitHub Actions](https://github.com/jenkinsci/coverage-plugin/workflows/GitHub%20CI/badge.svg)](https://github.com/jenkinsci/coverage-plugin/actions)
-[![Codecov](https://codecov.io/gh/jenkinsci/coverage/branch/master/graph/badge.svg)](https://codecov.io/gh/jenkinsci/coverage-plugin/branch/main)
+[![Codecov](https://codecov.io/gh/jenkinsci/coverage/branch/main/graph/badge.svg)](https://codecov.io/gh/jenkinsci/coverage-plugin/branch/main)
 [![CodeQL](https://github.com/jenkinsci/coverage/workflows/CodeQL/badge.svg)](https://github.com/jenkinsci/coverage/actions/workflows/codeql.yml)
 
 The Jenkins Coverage Plug-in collects reports of code coverage or mutation coverage tools. It has support for the following report formats:
@@ -173,8 +173,8 @@ recordCoverage(tools: [[parser: 'JACOCO']],
 The coverage plugin provides the token `COVERAGE` that could be used in additional post build processing steps, e.g. in the mailer. In order to use this token you need to install the [Token Macro plugin](https://plugins.jenkins.io/token-macro).
 The token has the following optional parameters:
 - `id`: selects a particular coverage result, if not defined the defauult  result that are published under the URL "coverage" are shown.
-- `metric`: selects the coverage metric to evaluate, see [Metric help](https://github.com/jenkinsci/coverage-plugin/blob/master/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/help-metric.html) for all possible values. 
-- `baseline`: selects the baseline to use, see [Baseline help](https://github.com/jenkinsci/coverage-plugin/blob/master/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/help-baseline.html) for all possible values. .
+- `metric`: selects the coverage metric to evaluate, see [Metric help](https://github.com/jenkinsci/coverage-plugin/blob/main/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/help-metric.html) for all possible values. 
+- `baseline`: selects the baseline to use, see [Baseline help](https://github.com/jenkinsci/coverage-plugin/blob/main/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/help-baseline.html) for all possible values. .
  
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Jenkins](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/coverage-plugin/job/main/)
 [![GitHub Actions](https://github.com/jenkinsci/coverage-plugin/workflows/GitHub%20CI/badge.svg)](https://github.com/jenkinsci/coverage-plugin/actions)
 [![Codecov](https://codecov.io/gh/jenkinsci/coverage/branch/main/graph/badge.svg)](https://codecov.io/gh/jenkinsci/coverage-plugin/branch/main)
-[![CodeQL](https://github.com/jenkinsci/coverage/workflows/CodeQL/badge.svg)](https://github.com/jenkinsci/coverage/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/jenkinsci/coverage-plugin/workflows/CodeQL/badge.svg)](https://github.com/jenkinsci/coverage-plugin/actions/workflows/codeql.yml)
 
 The Jenkins Coverage Plug-in collects reports of code coverage or mutation coverage tools. It has support for the following report formats:
 

--- a/plugin/src/main/resources/coverage/configuration.jelly
+++ b/plugin/src/main/resources/coverage/configuration.jelly
@@ -39,6 +39,9 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry field="ignoreParsingErrors">
+      <f:checkbox title="${%title.ignoreParsingErrors}"/>
+    </f:entry>
     <f:entry field="failOnError">
       <f:checkbox title="${%failOnError.title}"/>
     </f:entry>

--- a/plugin/src/main/resources/coverage/configuration.properties
+++ b/plugin/src/main/resources/coverage/configuration.properties
@@ -13,6 +13,7 @@ checksName.title=Checks name
 checksAnnotationScope.title=Select the scope of source code annotations
 failOnError.title=Fail the step if errors have been reported during the execution
 title.enabledForFailure=Enable recording for failed builds
+title.ignoreParsingErrors=Ignore parsing errors during processing of the coverage reports
 title.skipSymbolicLinks=Skip symbolic links when searching for files
 sourceCodeRetention.title=Source Code Retention Strategy
 

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder/help-ignoreParsingErrors.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder/help-ignoreParsingErrors.html
@@ -1,7 +1,7 @@
 <div>
     This toggle determines if the coverage plugin should ignore parsing errors during processing of the coverage
-    reports or if it should fail fast with an exception. By default this toggle is disabled and the
+    reports or if it should fail fast with an exception. By default, this toggle is disabled and the
     parsers will fail fast. This helps to identify bugs in the parser or in the coverage tool execution.
-    If you would rather like to ignore parsing errors, please tick this checkbox. Please note, that in this
+    If you would rather like to ignore parsing errors, please tick this checkbox. Please note that in this
     case the parser results might be incomplete or even wrong.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageStep/help-ignoreParsingErrors.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageStep/help-ignoreParsingErrors.html
@@ -1,7 +1,7 @@
 <div>
     This toggle determines if the coverage plugin should ignore parsing errors during processing of the coverage
-    reports or if it should fail fast with an exception. By default this toggle is disabled and the
+    reports or if it should fail fast with an exception. By default, this toggle is disabled and the
     parsers will fail fast. This helps to identify bugs in the parser or in the coverage tool execution.
-    If you would rather like to ignore parsing errors, please tick this checkbox. Please note, that in this
+    If you would rather like to ignore parsing errors, please tick this checkbox. Please note that in this
     case the parser results might be incomplete or even wrong.
 </div>


### PR DESCRIPTION
The option `ignoreParsingErrors` has been added to the API recently. It makes sense to expose this option in the UI configuration dialog as well.