### PR TITLE
[JENKINS-72317] Use Jenkins.READ permission check for all list box models

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGate.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGate.java
@@ -3,14 +3,12 @@ package io.jenkins.plugins.coverage.metrics.steps;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.util.VisibleForTesting;
 
-import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.verb.POST;
 import hudson.Extension;
-import hudson.model.AbstractProject;
-import hudson.model.Item;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.coverage.metrics.model.Baseline;
 import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
@@ -110,15 +108,12 @@ public class CoverageQualityGate extends QualityGate {
         /**
          * Returns a model with all {@link Metric metrics} that can be used in quality gates.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link Metric metrics}.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillMetricItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (jenkins.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillMetricItems() {
+            if (jenkins.hasPermission(Jenkins.READ)) {
                 return FORMATTER.getMetricItems();
             }
             return new ListBoxModel();
@@ -127,15 +122,12 @@ public class CoverageQualityGate extends QualityGate {
         /**
          * Returns a model with all {@link Metric metrics} that can be used in quality gates.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link Metric metrics}.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillBaselineItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (jenkins.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillBaselineItems() {
+            if (jenkins.hasPermission(Jenkins.READ)) {
                 return FORMATTER.getBaselineItems();
             }
             return new ListBoxModel();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -28,6 +28,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -41,6 +42,7 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.coverage.metrics.steps.CoverageTool.Parser;
 import io.jenkins.plugins.prism.SourceCodeDirectory;
@@ -544,15 +546,12 @@ public class CoverageRecorder extends Recorder {
         /**
          * Returns a model with all {@link SourceCodeRetention} strategies.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link SourceCodeRetention} strategies.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillSourceCodeRetentionItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillSourceCodeRetentionItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return SourceCodeRetention.fillItems();
             }
             return new ListBoxModel();
@@ -561,15 +560,12 @@ public class CoverageRecorder extends Recorder {
         /**
          * Returns a model with all {@link ChecksAnnotationScope} scopes.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link ChecksAnnotationScope} scopes.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillChecksAnnotationScopeItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillChecksAnnotationScopeItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return ChecksAnnotationScope.fillItems();
             }
             return new ListBoxModel();
@@ -578,15 +574,12 @@ public class CoverageRecorder extends Recorder {
         /**
          * Returns a model with all available charsets.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all available charsets
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ComboBoxModel doFillSourceCodeEncodingItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ComboBoxModel doFillSourceCodeEncodingItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return VALIDATION_UTILITIES.getAllCharsets();
             }
             return new ComboBoxModel();
@@ -604,7 +597,7 @@ public class CoverageRecorder extends Recorder {
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public FormValidation doCheckSourceCodeEncoding(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckSourceCodeEncoding(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String sourceCodeEncoding) {
             if (!JENKINS.hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();
@@ -624,7 +617,7 @@ public class CoverageRecorder extends Recorder {
          * @return the validation result
          */
         @POST
-        public FormValidation doCheckId(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckId(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String id) {
             if (!JENKINS.hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
@@ -26,7 +26,7 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.AbstractProject;
+import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -34,6 +34,7 @@ import hudson.tools.ToolDescriptor;
 import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.prism.SourceCodeDirectory;
 import io.jenkins.plugins.prism.SourceCodeRetention;
@@ -403,15 +404,12 @@ public class CoverageStep extends Step implements Serializable {
         /**
          * Returns a model with all {@link SourceCodeRetention} strategies.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link SourceCodeRetention} strategies.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillSourceCodeRetentionItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillSourceCodeRetentionItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return SourceCodeRetention.fillItems();
             }
             return new ListBoxModel();
@@ -420,15 +418,12 @@ public class CoverageStep extends Step implements Serializable {
         /**
          * Returns a model with all {@link ChecksAnnotationScope} scopes.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all {@link ChecksAnnotationScope} scopes.
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ListBoxModel doFillChecksAnnotationScopeItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillChecksAnnotationScopeItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return ChecksAnnotationScope.fillItems();
             }
             return new ListBoxModel();
@@ -438,15 +433,12 @@ public class CoverageStep extends Step implements Serializable {
         /**
          * Returns a model with all available charsets.
          *
-         * @param project
-         *         the project that is configured
-         *
          * @return a model with all available charsets
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public ComboBoxModel doFillSourceCodeEncodingItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ComboBoxModel doFillSourceCodeEncodingItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 return VALIDATION_UTILITIES.getAllCharsets();
             }
             return new ComboBoxModel();
@@ -464,7 +456,7 @@ public class CoverageStep extends Step implements Serializable {
          */
         @POST
         @SuppressWarnings("unused") // used by Stapler view data binding
-        public FormValidation doCheckSourceCodeEncoding(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckSourceCodeEncoding(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String sourceCodeEncoding) {
             if (!JENKINS.hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();
@@ -484,7 +476,7 @@ public class CoverageStep extends Step implements Serializable {
          * @return the validation result
          */
         @POST
-        public FormValidation doCheckId(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckId(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String id) {
             if (!JENKINS.hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
@@ -19,11 +19,12 @@ import org.kohsuke.stapler.verb.POST;
 import org.jvnet.localizer.Localizable;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
-import hudson.model.AbstractProject;
+import hudson.model.BuildableItem;
 import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.prism.SourceCodeRetention;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -139,13 +140,11 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
         /**
          * Returns a model with all {@link SourceCodeRetention} strategies.
          *
-         * @param project
-         *         the project that is configured
          * @return a model with all {@link SourceCodeRetention} strategies.
          */
         @POST
-        public ListBoxModel doFillParserItems(@AncestorInPath final AbstractProject<?, ?> project) {
-            if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        public ListBoxModel doFillParserItems() {
+            if (JENKINS.hasPermission(Jenkins.READ)) {
                 ListBoxModel options = new ListBoxModel();
                 add(options, Parser.JACOCO);
                 add(options, Parser.COBERTURA);
@@ -170,7 +169,7 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
          * @return the validation result
          */
         @POST
-        public FormValidation doCheckId(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckId(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String id) {
             if (!new JenkinsFacade().hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();


### PR DESCRIPTION
Additionally, use permissions for a `BuildableItem` in all validations.

See https://issues.jenkins.io/browse/JENKINS-72317 for details.