### PR TITLE
[JENKINS-72448] Make sure that logging statements are in correct order

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel.java
@@ -27,6 +27,7 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Percentage;
 import edu.hm.hafner.echarts.LabeledTreeMapNode;
 import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -115,6 +116,11 @@ public class CoverageViewModel extends DefaultAsyncTableContentProvider implemen
         modifiedLinesCoverageTreeRoot = node.filterByModifiedLines();
         indirectCoverageChangesTreeRoot = node.filterByIndirectChanges();
         this.trendChartFunction = trendChartFunction;
+    }
+
+    @VisibleForTesting
+    FilteredLog getLog() {
+        return log;
     }
 
     public String getId() {
@@ -440,16 +446,16 @@ public class CoverageViewModel extends DefaultAsyncTableContentProvider implemen
     }
 
     /**
-     * Returns a new sub-page for the selected link.
+     * Returns a new subpage for the selected link.
      *
      * @param link
-     *         the link to identify the sub-page to show
+     *         the link to identify the subpage to show
      * @param request
      *         Stapler request
      * @param response
      *         Stapler response
      *
-     * @return the new sub-page
+     * @return the new subpage
      */
     @SuppressWarnings("unused") // Called by jelly view
     @CheckForNull

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/PathResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/PathResolver.java
@@ -132,11 +132,11 @@ public class PathResolver {
                         mapping.size(), relativePaths.size() - mapping.size());
             }
 
-            var changedFilesMapping = mapping.entrySet()
+            var changedFileMapping = mapping.entrySet()
                     .stream()
                     .filter(entry -> !entry.getKey().equals(entry.getValue()))
                     .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-            var result = new RemoteResultWrapper<>(new HashMap<>(changedFilesMapping), "Errors during source path resolving:");
+            var result = new RemoteResultWrapper<>(new HashMap<>(changedFileMapping), "Errors during source path resolving:");
             result.merge(log);
             return result;
         }
@@ -149,7 +149,6 @@ public class PathResolver {
 
         private Optional<String> locateSource(final String relativePath, final FilePath workspace,
                 final Set<String> sourceSearchDirectories, final FilteredLog log) {
-
             try {
                 FilePath absolutePath = new FilePath(new File(relativePath));
                 if (absolutePath.exists()) {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
@@ -295,6 +295,60 @@ class CoveragePluginITest extends AbstractCoverageITest {
                         .withCovered(JACOCO_ANALYSIS_MODEL_COVERED + COBERTURA_COVERED_LINES)
                         .withMissed(JACOCO_ANALYSIS_MODEL_MISSED)
                         .build());
+
+        assertThat(getConsoleLog(build)).contains(
+                "[Coverage] Recording coverage results",
+                "[Coverage] Creating parser for Cobertura Coverage Reports",
+                "that match the pattern 'cobertura-higher-coverage.xml'",
+                "Successfully processed file 'cobertura-higher-coverage.xml'",
+                "[Coverage] Creating parser for JaCoCo Coverage Reports",
+                "that match the pattern 'jacoco-analysis-model.xml'",
+                "Successfully processed file 'jacoco-analysis-model.xml'");
+        var log = coverageResult.getLog();
+        assertThat(log.getInfoMessages()).contains("Recording coverage results",
+                "Creating parser for Cobertura Coverage Reports",
+                "Successfully processed file 'cobertura-higher-coverage.xml'",
+                "Creating parser for JaCoCo Coverage Reports",
+                "Successfully processed file 'jacoco-analysis-model.xml'",
+                "Resolving source code files...",
+                "-> finished resolving of absolute paths (found: 0, not found: 308)",
+                "Obtaining action of reference build",
+                "Reference build recorder is not configured",
+                "-> Found no reference result in reference build",
+                "No quality gates have been set - skipping",
+                "Executing source code painting...",
+                "Painting 308 source files on agent",
+                "-> finished painting (0 files have been painted, 308 files failed)",
+                "Copying painted sources from agent to build folder",
+                "-> extracting...",
+                "-> done",
+                "Finished coverage processing - adding the action to the build...");
+        assertThat(log.getErrorMessages()).contains("Errors while recording code coverage:",
+                "Errors during source path resolving:",
+                "Errors while resolving source files on agent:",
+                "Removing non-workspace source directory '/Users/leobalter/dev/testing/solutions/3' - it has not been approved in Jenkins' global configuration.",
+                "- Source file 'edu/hm/hafner/analysis/parser/PerlCriticParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/StyleCopParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/RoboCopyDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/fxcop/FxCopRuleSet.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/SpotBugsDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/AcuCobolParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/FlexSdkDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/BrakemanDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/PyDocStyleDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/AjcParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/ReaderFactory.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/DiabCParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/OELintAdvDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/GnuFortranDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/parser/Armcc5CompilerParser.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/DoxygenDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/ProtoLintDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/registry/GoLintDescriptor.java' not found",
+                "- Source file 'edu/hm/hafner/analysis/ModuleResolver.java' not found",
+                "  ... skipped logging of 289 additional errors ...",
+                "  ... skipped logging of 289 additional errors ...",
+                "  ... skipped logging of 289 additional errors ...");
     }
 
     @Test


### PR DESCRIPTION
Use a unique log handler so that all logging statements are shown only once and in the correct order. Also make sure that all log statements are persisted, otherwise the view "coverage/info" shows only a part of the log.

Note: [codingstyle v3.31.0](https://github.com/uhafner/codingstyle/releases/tag/v3.31.0) is required as well to correctly show merged error messages in the correct order. 