### PR TITLE
Include NUnit parser from coverage-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Jenkins Coverage Plug-in collects reports of code coverage or mutation cover
 - [OpenCover](https://github.com/OpenCover/opencover): Code Coverage
 - [PIT](https://pitest.org/): Mutation Coverage
 - [JUnit](https://ant.apache.org/manual/Tasks/junitreport.html): Test Results
+- [NUnit](https://nunit.org/): Test Results
 
 If your coverage tool is not yet supported by the coverage plugin, feel free to provide a pull request for the [Coverage Model](https://github.com/jenkinsci/coverage-model/pulls).
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
     <gitHubRepo>jenkinsci/coverage-plugin</gitHubRepo>
 
     <!-- Library Dependencies Versions -->
-    <coverage-model.version>0.38.0</coverage-model.version>
+    <coverage-model.version>0.39.0</coverage-model.version>
     <jsoup.version>1.17.2</jsoup.version>
 
     <!-- Jenkins Plug-in Dependencies Versions -->

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
@@ -151,6 +151,7 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
                 add(options, Parser.OPENCOVER);
                 add(options, Parser.PIT);
                 add(options, Parser.JUNIT);
+                add(options, Parser.NUNIT);
                 return options;
             }
             return new ListBoxModel();
@@ -213,6 +214,8 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
         PIT(Messages._Parser_PIT(), "**/mutations.xml",
                 "symbol-solid/virus-slash plugin-font-awesome-api"),
         JUNIT(Messages._Parser_Junit(), "**/TEST-*.xml",
+                "symbol-solid/list-check plugin-font-awesome-api"),
+        NUNIT(Messages._Parser_Nunit(), "**/nunit.xml,**/TestResult.xml",
                 "symbol-solid/list-check plugin-font-awesome-api");
 
         private final Localizable displayName;

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/Messages.properties
@@ -5,6 +5,7 @@ Parser.JaCoCo=JaCoCo Coverage Reports
 Parser.OpenCover=OpenCover Coverage Reports
 Parser.PIT=PIT Mutation Testing Reports
 Parser.Junit=JUnit Test Results
+Parser.Nunit=NUnit Test Results
 
 Coverage.Not.Available=n/a
 Coverage.Link.Name=Coverage Report

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
 import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.TestCount;
 import edu.hm.hafner.coverage.Value;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -405,6 +406,21 @@ class CoveragePluginITest extends AbstractCoverageITest {
                 .isInstanceOfSatisfying(Coverage.class, m -> {
                     assertThat(m.getCovered()).isEqualTo(9);
                     assertThat(m.getTotal()).isEqualTo(15);
+                });
+    }
+
+    @Test
+    void shouldRecordOneNUnitResultInFreestyleJob() {
+        FreeStyleProject project = createFreestyleJob(Parser.NUNIT, "nunit.xml");
+
+        Run<?, ?> build = buildSuccessfully(project);
+
+        CoverageBuildAction coverageResult = build.getAction(CoverageBuildAction.class);
+        assertThat(coverageResult.getAllValues(Baseline.PROJECT))
+                .filteredOn(Value::getMetric, Metric.TESTS)
+                .first()
+                .isInstanceOfSatisfying(TestCount.class, m -> {
+                    assertThat(m.getValue()).isEqualTo(4);
                 });
     }
 

--- a/plugin/src/test/resources/io/jenkins/plugins/coverage/metrics/steps/nunit.xml
+++ b/plugin/src/test/resources/io/jenkins/plugins/coverage/metrics/steps/nunit.xml
@@ -1,0 +1,29 @@
+<test-run id="2" duration="0.46225700000000003" testcasecount="4" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:37Z" end-time="2024-01-23T 12:33:47Z">
+  <test-suite type="Assembly" name="test.dll" fullname="/home/jenkins/bin/Debug/net8.0/test.dll" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+    <test-suite type="TestSuite" name="test" fullname="test" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+      <test-suite type="TestFixture" name="Tests" fullname="test.Tests" classname="test.Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.462257">
+        <test-case name="FailedTEst" fullname="test.Tests.FailedTEst" methodname="FailedTEst" classname="Tests" result="Failed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.057283" asserts="0" seed="1556857297">
+          <failure>
+            <message>  Expected string length 4 but was 5. Strings differ at index 4.
+  Expected: "Test"
+  But was:  "Test1"
+  ---------------^
+</message>
+            <stack-trace>   at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+
+1)    at test.Tests.FailedTEst() in /home/jenkins/Tests.cs:line 50
+
+</stack-trace>
+          </failure>
+        </test-case>
+        <test-case name="IgnoredTest" fullname="test.Tests.IgnoredTest" methodname="IgnoredTest" classname="Tests" result="Skipped" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:46Z" duration="0.000378" asserts="0" seed="1438305193">
+          <output><![CDATA[Skipping this test
+]]></output>
+        </test-case>
+        <test-case name="ShouldConnectToDatabase" fullname="test.Tests.ShouldConnectToDatabase" methodname="ShouldConnectToDatabase" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:46Z" end-time="2024-01-23T 12:33:47Z" duration="0.404245" asserts="0" seed="802014458" />
+        <test-case name="ShouldCreateItem" fullname="test.Tests.ShouldCreateItem" methodname="ShouldCreateItem" classname="Tests" result="Passed" start-time="2024-01-23T 12:33:47Z" end-time="2024-01-23T 12:33:47Z" duration="0.000351" asserts="0" seed="606875445" />
+      </test-suite>
+    </test-suite>
+    <errors />
+  </test-suite>
+</test-run>


### PR DESCRIPTION
Include NUnit parser from coverage-model from https://github.com/jenkinsci/coverage-model/pull/69

### Testing done

Automated tests and create one integration test

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
