### PR TITLE
[JENKINS-72770] Add example for reference builds with old default logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,12 @@ In order to compute this classification, the plugin requires a reference build (
 
 ### Selecting a baseline from the current job
 
-When a team wants to investigate how the coverage of the project changes over the time, we need to simply look back in the history of the same Jenkins job and select another build that we can use to compare the results with. Such a Jenkins job typically builds the main branch of the source control system. This behavior is available out-of-the-box without any additional configuration. 
+When a team wants to investigate how the coverage of the project changes over the time, we need to simply look back in the history of the same Jenkins job and select another build that we can use to compare the results with. Such a Jenkins job typically builds the main branch of the source control system. This can be achieved by using `discoverReferenceBuild` before the step to record the coverage coverage:
+
+```groovy
+discoverReferenceBuild()
+recordCoverage(tools: [[parser: 'JACOCO']])
+```
 
 ### Selecting a baseline in the target job
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ In order to compute this classification, the plugin requires a reference build (
 
 ### Selecting a baseline from the current job
 
-When a team wants to investigate how the coverage of the project changes over the time, we need to simply look back in the history of the same Jenkins job and select another build that we can use to compare the results with. Such a Jenkins job typically builds the main branch of the source control system. This can be achieved by using `discoverReferenceBuild` before the step to record the coverage coverage:
+When a team wants to investigate how the coverage of the project changes over the time, we need to simply look back in the history of the same Jenkins job and select another build that we can use to compare the results with. Such a Jenkins job typically builds the main branch of the source control system. This can be achieved by using `discoverReferenceBuild` before the step to record the code coverage:
 
 ```groovy
 discoverReferenceBuild()


### PR DESCRIPTION
Version 0.11.0 changed the behavior of reference builds. Document how to achieve the same results as for versions up to 0.10.0. Related to JENKINS-72770.

See also: https://issues.jenkins.io/browse/JENKINS-72770.

### Testing done

Not relevant.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```