### PR TITLE
Bump version of coverage-model to 0.41.0

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
     <gitHubRepo>jenkinsci/coverage-plugin</gitHubRepo>
 
     <!-- Library Dependencies Versions -->
-    <coverage-model.version>0.40.0</coverage-model.version>
+    <coverage-model.version>0.41.0</coverage-model.version>
     <jsoup.version>1.17.2</jsoup.version>
 
     <!-- Jenkins Plug-in Dependencies Versions -->


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/coverage-model/pull/82.