### PR TITLE
Restyle the tables and inline the new files filter.

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -142,6 +142,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>data-tables-api</artifactId>
+      <version>2.0.1-1</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/resources/coverage/coverage-table.jelly
+++ b/plugin/src/main/resources/coverage/coverage-table.jelly
@@ -24,18 +24,20 @@
       <j:when test="${it.hasSourceCode()}">
         <div class="col-12 d-xxl-none">
           <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100" >
-            <j:if test="${showChangedToggle}">
-              <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}" />
-            </j:if>
-            <dt:table model="${it.getTableModel(id + '-table')}"/>
+            <dt:table model="${it.getTableModel(id + '-table')}">
+              <j:if test="${showChangedToggle}">
+                <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}" />
+              </j:if>
+            </dt:table>
           </bs:card>
         </div>
         <div class="col-xxl-6 d-none d-xxl-block">
           <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100">
-            <j:if test="${showChangedToggle}">
-              <f:toggleSwitch id="changed-${id + '-table-inline'}" title="${%changed.files}" />
-            </j:if>
-            <dt:table model="${it.getTableModel(id + '-table-inline')}"/>
+            <dt:table model="${it.getTableModel(id + '-table-inline')}">
+              <j:if test="${showChangedToggle}">
+                <f:toggleSwitch id="changed-${id + '-table-inline'}" title="${%changed.files}" />
+              </j:if>
+            </dt:table>
           </bs:card>
         </div>
         <div class="col-xxl-6 d-none d-xxl-block">
@@ -66,11 +68,12 @@
       </j:when>
       <j:otherwise>
         <div class="col-12">
-          <j:if test="${showChangedToggle}">
-            <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}" />
-          </j:if>
           <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100">
-            <dt:table model="${it.getTableModel(id + '-table')}"/>
+            <dt:table model="${it.getTableModel(id + '-table')}">
+              <j:if test="${showChangedToggle}">
+                <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}"/>
+              </j:if>
+            </dt:table>
           </bs:card>
         </div>
 


### PR DESCRIPTION
With DataTables 2.x it is much easier to style the table toolbar. The new files toggle is now moved to the tables controls.

Before:
![Bildschirmfoto 2024-03-06 um 22 55 42](https://github.com/jenkinsci/coverage-plugin/assets/503338/6947a086-5696-4441-9efb-0e6d7a9cbd87)


After:

![Bildschirmfoto 2024-03-06 um 22 54 34](https://github.com/jenkinsci/coverage-plugin/assets/503338/87a09268-83ce-4a71-9040-836f51d377e3)
