### PR TITLE
Automatic parser detection

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -560,7 +560,6 @@ public class CoverageRecorder extends Recorder {
             }
             if (!anySucceed) {
                 var errorMessage = "Attempted all parsers and none succeeded.";
-                LOGGER.info(errorMessage);
                 logHandler.log(errorMessage);
                 if (isFailOnError()) {
                     resultHandler.setResult(Result.FAILURE, errorMessage);

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -473,7 +473,7 @@ public class CoverageRecorder extends Recorder {
      * The simplified error messages are in the following format: Attempted parser <PARSER> with pattern <PATTERN>, but was unsuccessful.
      */
     private Map<Parser, List<ModuleNode>> recordCoverageResults(final Run<?, ?> run, final FilePath workspace,
-                                                                final StageResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
+                                                                final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
         Map<Parser, List<ModuleNode>> results = new HashMap<>();
 
         CoverageToolExpander covToolExpander = new CoverageToolExpander(this.tools, log, logHandler);
@@ -508,7 +508,7 @@ public class CoverageRecorder extends Recorder {
                         if (isFailOnError() && !toolSet.isExpanded()) {
                             var errorMessage = "Failing build due to some errors during recording of the coverage";
                             localLog.logInfo(errorMessage);
-                            resultHandler.setResult(Result.FAILURE, errorMessage);
+                            resultHandler.publishResult(Result.FAILURE, errorMessage);
                         }
                         else {
                             localLog.logInfo("Ignore errors and continue processing");
@@ -548,7 +548,7 @@ public class CoverageRecorder extends Recorder {
     /*
      * Resolve logs after the completion of a set of expanded tools
      */
-    private void resolveToolSetLogs(HashMap<CoverageTool, FilteredLog> parsersErrLogs, boolean anySucceed, boolean isExpansionSet, FilteredLog log, LogHandler logHandler, StageResultHandler resultHandler) {
+    private void resolveToolSetLogs(HashMap<CoverageTool, FilteredLog> parsersErrLogs, boolean anySucceed, boolean isExpansionSet, FilteredLog log, LogHandler logHandler, ResultHandler resultHandler) {
         if (isExpansionSet) {
             for (CoverageTool tool: parsersErrLogs.keySet()) {
                 if (anySucceed) { // if any succeed, print simplified failure msg
@@ -562,7 +562,7 @@ public class CoverageRecorder extends Recorder {
                 var errorMessage = "Attempted all parsers and none succeeded.";
                 logHandler.log(errorMessage);
                 if (isFailOnError()) {
-                    resultHandler.setResult(Result.FAILURE, errorMessage);
+                    resultHandler.publishResult(Result.FAILURE, errorMessage);
                 }
             }
             parsersErrLogs.clear();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
@@ -46,7 +46,7 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
     private JenkinsFacade jenkins = new JenkinsFacade();
 
     private String pattern = StringUtils.EMPTY;
-    private Parser parser = Parser.JACOCO;
+    private Parser parser;
 
     /**
      * Creates a new {@link io.jenkins.plugins.coverage.metrics.steps.CoverageTool}.

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageToolExpander.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageToolExpander.java
@@ -164,7 +164,6 @@ public class CoverageToolExpander {
             return tools.get(index++);
         }
 
-        @org.jetbrains.annotations.NotNull
         @Override
         public Iterator<CoverageTool> iterator() {
             return new CoverageToolIterator();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageToolExpander.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageToolExpander.java
@@ -1,0 +1,188 @@
+package io.jenkins.plugins.coverage.metrics.steps;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.util.FilteredLog;
+import hudson.model.Run;
+import hudson.tasks.Recorder;
+import io.jenkins.plugins.coverage.metrics.steps.CoverageTool.Parser;
+import io.jenkins.plugins.util.LogHandler;
+
+/**
+ * Expands a list of given {@link CoverageTool}'s into the actual CoverageTool's set that {@link CoverageRecorder} uses when attempting to look for and parse coverage files.
+ * <p>
+ * The CoverageTool to its working set mapping use the following rules:
+ * - Empty or null tool set -&gt; set of all possible coverage parsers with null patterns (which will default to their default patterns)
+ * - Tool with a Pattern no {@link Parser} -&gt; set of the Pattern paired with every possible Parser
+ * - Tool with a {@link Parser} but no pattern -&gt; set of just the input tool
+ * - Tool with both a {@link Parser} and Pattern -&gt; set of just the input tool
+ * </p>
+ * <p>
+ * Use {@code hasNextTool() } and {@code useNextTool() } methods to iterate through the mappings.
+ * </p>
+ *
+ * @author Pierson Yieh
+ */
+public class CoverageToolExpander {
+    HashMap<CoverageTool, CoverageToolSet> toolMap;
+    FilteredLog log;
+    LogHandler logHandler;
+
+    CoverageTool currTool;
+    Iterator<CoverageTool> toolIter;
+
+    public final static CoverageToolSet DEFAULT_TOOLS = new CoverageToolSet() {
+        {
+            this.isExpanded = true;
+            for (Parser parser: Parser.values()) {
+                if (!(parser == Parser.JUNIT || parser == Parser.NUNIT || parser == Parser.XUNIT)) {
+                    tools.add(new CoverageTool(parser, null));
+                }
+            }
+        }
+    };
+
+    public CoverageToolExpander(List<CoverageTool> tools, FilteredLog log, LogHandler logHandler) {
+        this.toolMap = new HashMap<>();
+        this.log = log;
+        this.logHandler = logHandler;
+        initTools(tools);
+    }
+
+    /**
+     * Initializes the current {@code CoverageToolExpander} with the expanded tools' mapping.
+     *
+     * @param tools
+     *          Input list of {@code CoverageTool}'s to expand
+     */
+    public void initTools(List<CoverageTool> tools) {
+        this.toolMap.clear();
+        addExpandedTools(tools);
+    }
+
+    private void logInfo(String msg) {
+        log.logInfo(msg);
+        logHandler.log(log);
+    }
+
+    /**
+     * Does the actual expansion of each CoverageTool and maps its expansion in {@code toolMap}
+     * @param tools
+     *          Input list of {@code CoverageTool}'s to expand
+     */
+    public void addExpandedTools(List<CoverageTool> tools) {
+        if (tools == null || tools.isEmpty()) { // empty or no tools -> DEFAULT_TOOLS
+            logInfo("No tool defined, trying all possible parsers.");
+            toolMap.put(null, DEFAULT_TOOLS);
+        } else {
+            for (CoverageTool tool: tools) {
+                if (tool.getParser() == null) {
+                    if (tool.getPattern() == null || tool.getPattern().isBlank()) { // empty tool -> DEFAULT_TOOLS
+                        logInfo("Empty tool given, trying all possible parsers.");
+                        toolMap.put(tool, DEFAULT_TOOLS);
+                    } else { // tool has just pattern -> try input pattern with each parser
+                        logInfo(String.format("No parser defined for pattern [%s], trying with all possible parsers.", tool.getPattern()));
+                        toolMap.put(tool, patternWithAllParsers(tool.getPattern()));
+                    }
+                } else { // tool has parser , leave as is (regardless if has pattern or not)
+                    toolMap.put(tool, new CoverageToolSet(Arrays.asList(tool), false));
+                }
+            }
+        }
+        toolIter = toolMap.keySet().iterator();
+    }
+
+    public CoverageToolSet patternWithAllParsers(String pattern) {
+        CoverageToolSet ret = new CoverageToolSet();
+        ret.isExpanded = true;
+        for (Parser p: Parser.values()) {
+            ret.addTool(new CoverageTool(p, pattern));
+        }
+        return ret;
+    }
+
+    public boolean hasNextTool() {
+        return toolIter.hasNext();
+    }
+
+    public CoverageTool getNextTool() {
+        currTool = toolIter.next();
+        return currTool;
+    }
+
+    public CoverageToolSet getCoverageToolSet(CoverageTool tool) {
+        return toolMap.get(tool);
+    }
+
+    /**
+     * A list of {@link CoverageTool}'s that represent an expansion of a given input CoverageTool
+     */
+    public static class CoverageToolSet implements Iterable<CoverageTool> {
+        List<CoverageTool> tools;
+        boolean isExpanded;
+        int index = 0;
+
+        public CoverageToolSet() {
+            this.tools = new ArrayList<>();
+        }
+
+        public CoverageToolSet(List<CoverageTool> tools, boolean isExpanded) {
+            this.tools = tools;
+            this.isExpanded = isExpanded;
+        }
+
+        public List<CoverageTool> getTools() {
+            return tools;
+        }
+
+        public void setTools(List<CoverageTool> tools) {
+            this.tools = tools;
+        }
+
+        public void addTool(CoverageTool tool) {
+            if (this.tools == null) {
+                this.tools = new ArrayList<>();
+            }
+            this.tools.add(tool);
+        }
+
+        public boolean isExpanded() {
+            return isExpanded;
+        }
+
+        public void setExpanded(boolean expanded) {
+            isExpanded = expanded;
+        }
+
+        public boolean hasNext() {
+            return index < tools.size();
+        }
+
+        public CoverageTool getNext() {
+            return tools.get(index++);
+        }
+
+        @org.jetbrains.annotations.NotNull
+        @Override
+        public Iterator<CoverageTool> iterator() {
+            return new CoverageToolIterator();
+        }
+
+        private class CoverageToolIterator implements Iterator<CoverageTool> {
+            private int currentIndex = 0;
+
+            @Override
+            public boolean hasNext() {
+                return currentIndex < tools.size();
+            }
+
+            @Override
+            public CoverageTool next() {
+                return tools.get(currentIndex++);
+            }
+        }
+
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
@@ -41,24 +41,6 @@ class CoveragePluginITest extends AbstractCoverageITest {
     private static final int COBERTURA_MISSED_LINES = 0;
     private static final String NO_FILES_FOUND_ERROR_MESSAGE = "[-ERROR-] No files found for pattern '**/*xml'. Configuration error?";
 
-    @Test
-    void shouldFailWithoutParserInFreestyleJob() {
-        FreeStyleProject project = createFreeStyleProject();
-
-        project.getPublishersList().add(new CoverageRecorder());
-
-        verifyNoParserError(project);
-    }
-
-    @Test
-    void shouldFailWithoutParserInPipeline() {
-        WorkflowJob job = createPipeline();
-
-        setPipelineScript(job, "recordCoverage()");
-
-        verifyNoParserError(job);
-    }
-
     private void verifyNoParserError(final ParameterizedJob<?, ?> project) {
         Run<?, ?> run = buildWithResult(project, Result.FAILURE);
 

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
@@ -147,8 +147,4 @@ class CoverageRecorderITest extends IntegrationTestWithJenkinsPerSuite {
                 .containsPattern("Successfully parsed file .*/cobertura-higher-coverage.xml");
 
     }
-<<<<<<< Updated upstream
-=======
-
->>>>>>> Stashed changes
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
@@ -147,4 +147,8 @@ class CoverageRecorderITest extends IntegrationTestWithJenkinsPerSuite {
                 .containsPattern("Successfully parsed file .*/cobertura-higher-coverage.xml");
 
     }
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
Change to the plugin behavior when no parser is provided in the tool field. Previous behavior was to error out. Now, the following scenarios can occur with their corresponding behavior:

**_Note_** Simplified error message is in the format: `Attempted parser <PARSER> with pattern <PATTERN>, but was unsuccessful.`

1) No tool is defined (i.e. no parser or pattern) & at least 1 parser is successful:
   - ex call)`recordCoverage(tools: [])`
   - Try each possible parser with its corresponding default pattern
   - Print the successful parsers' logs and a simplified error message for each parser that failed.
   Snippet of example output [Successful Go coverage, rest fail]:    
![image](https://github.com/jenkinsci/coverage-plugin/assets/11794153/c857e767-35f1-48cf-8cbd-f83bd2e14a03)

2) No tool is defined (i.e. no parser or pattern) & all parsers fail 
   - ex call) `recordCoverage(tools: [])`
   - Try each possible parser with its corresponding default pattern
   - Print the logs of each parser tried.
   Snippet of example output [All fail]:
![image](https://github.com/jenkinsci/coverage-plugin/assets/11794153/3bcb3fb8-b333-4cc5-b67d-a80b091d86f3)

3) At least 1 pattern is defined, but none of them have a corresponding parser: 
   - ex call) `recordCoverage(tools: [[pattern: '*coverage.out'], [pattern: '*coverage.xml']])`
   - Try each input pattern with each possible parser. 
   - Follows same ruling as above:
      - 1+ successful -> print verbose logs of successful combination, simplified error message of other combinations
      - All fail -> print verbose logs of all
   Snippet of example output [2 patterns for Go & Python coverage successfully get auto detected]:
![image](https://github.com/jenkinsci/coverage-plugin/assets/11794153/0a7c93d8-0ca1-47de-b5a0-828656c279b0)

**_Note_** Scenario 3 can occur even if another tool with a Parser is defined. Treats the expansion of that tool as 1 set.
ex call) `recordCoverage(tools: [[parser: 'JACOCO'], [pattern: '*coverage.xml']])`

### Testing done
Tested on a local instance of Jenkins running the plugin version. Ran the aforementioned scenarios via pipeline jobs and recorded their builds' console output. 
Also created unit tests that test the same thing.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```