### PR TITLE
[JENKINS-73175] Improve handling of duplicate nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build with Maven
         env:
           BROWSER: chrome-container
-        run: mvn -V --color always -ntp clean verify '-Djenkins.test.timeout=5000' '-Pci'
+        run: mvn -V --color always -ntp clean verify '-Djenkins.test.timeout=5000' '-Dgpg.skip'

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
     <gitHubRepo>jenkinsci/coverage-plugin</gitHubRepo>
 
     <!-- Library Dependencies Versions -->
-    <coverage-model.version>0.43.0</coverage-model.version>
+    <coverage-model.version>0.45.0</coverage-model.version>
     <jsoup.version>1.17.2</jsoup.version>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
@@ -312,111 +312,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>${maven-pmd-plugin.version}</version>
-        <configuration>
-          <linkXRef>false</linkXRef>
-          <targetJdk>${java.version}</targetJdk>
-          <skip>true</skip>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-core</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-java</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-javascript</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>edu.hm.hafner</groupId>
-            <artifactId>codingstyle</artifactId>
-            <version>${codingstyle.config.version}</version>
-            <classifier>config</classifier>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>run-pmd-java</id>
-            <goals>
-              <goal>pmd</goal>
-              <goal>check</goal>
-              <goal>cpd</goal>
-            </goals>
-            <phase>verify</phase>
-            <configuration>
-              <targetDirectory>${project.build.directory}/pmd-java</targetDirectory>
-              <rulesets>
-                <ruleset>pmd-java-configuration.xml</ruleset>
-              </rulesets>
-              <includeTests>false</includeTests>
-              <minimumTokens>50</minimumTokens>
-              <skip>${pmd.skip}</skip>
-              <excludes>
-                <exclude>**/steps/CoverageMetricColumn*</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>run-pmd-tests</id>
-            <goals>
-              <goal>pmd</goal>
-              <goal>check</goal>
-              <goal>cpd</goal>
-            </goals>
-            <phase>verify</phase>
-            <configuration>
-              <targetDirectory>${project.build.directory}/pmd-tests</targetDirectory>
-              <rulesets>
-                <ruleset>pmd-tests-configuration.xml</ruleset>
-              </rulesets>
-              <includeTests>true</includeTests>
-              <minimumTokens>100</minimumTokens>
-              <excludeRoots>
-                <excludeRoot>src/main/java</excludeRoot>
-                <excludeRoot>${project.build.directory}/generated-test-sources/injected</excludeRoot>
-                <excludeRoot>${project.build.directory}/generated-test-sources/test-annotations</excludeRoot>
-                <excludeRoot>${project.build.directory}/generated-test-sources/assertj-assertions</excludeRoot>
-              </excludeRoots>
-              <skip>${pmd.skip}</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>run-pmd-javascript</id>
-            <goals>
-              <goal>pmd</goal>
-              <goal>check</goal>
-            </goals>
-            <phase>verify</phase>
-            <configuration>
-              <targetDirectory>${project.build.directory}/pmd-javascript</targetDirectory>
-              <rulesets>
-                <ruleset>pmd-javascript-configuration.xml</ruleset>
-              </rulesets>
-              <includeTests>false</includeTests>
-              <language>javascript</language>
-              <compileSourceRoots>
-                <compileSourceRoot>src/main/resources</compileSourceRoot>
-                <compileSourceRoot>src/main/webapp/js</compileSourceRoot>
-              </compileSourceRoots>
-              <includes>
-                <include>**/*.js</include>
-              </includes>
-              <skip>${pmd.skip}</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-assertions-generator-maven-plugin</artifactId>

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderITest.java
@@ -30,7 +30,7 @@ class CoverageRecorderITest extends IntegrationTestWithJenkinsPerSuite {
         Run<?, ?> failure = buildWithResult(job, Result.FAILURE);
 
         assertThat(getConsoleLog(failure))
-                .contains("java.lang.IllegalArgumentException: There is already a child [METHOD] Enumerate()");
+                .contains("java.lang.IllegalArgumentException: There is already the same child [METHOD] Enumerate()");
 
         job.setDefinition(new CpsFlowDefinition(
                 "node {\n"
@@ -40,8 +40,7 @@ class CoverageRecorderITest extends IntegrationTestWithJenkinsPerSuite {
         Run<?, ?> success = buildWithResult(job, Result.SUCCESS);
 
         assertThat(getConsoleLog(success))
-                .doesNotContain("java.lang.IllegalArgumentException")
-                .contains("[-ERROR-] Found a duplicate method 'Enumerate' with signature '()' in 'VisualOn.Data.DataSourceProvider'");
+                .doesNotContain("java.lang.IllegalArgumentException");
     }
 
     @Test

--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoverageReport.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoverageReport.java
@@ -219,6 +219,7 @@ public class CoverageReport extends PageObject {
          * @return the tab
          * @throws NoSuchElementException if the tab could not be found
          */
+        @SuppressWarnings("PMD.UnnecessaryFullyQualifiedName")
         static Tab valueWithHref(final String href) {
             for (Tab tab : Tab.values()) {
                 if (tab.id.equals(href.substring(1))) {

--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoverageSummary.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoverageSummary.java
@@ -31,6 +31,7 @@ public class CoverageSummary extends PageObject {
      * @param id
      *         the type of the result page (e.g. simian, checkstyle, cpd, etc.)
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public CoverageSummary(final Build parent, final String id) {
         super(parent, parent.url(id));
 

--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/publisher/Adapter.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/publisher/Adapter.java
@@ -57,7 +57,7 @@ public class Adapter extends PageAreaImpl {
      */
     public AdapterThreshold createThresholdsPageArea() {
         ensureAdvancedOptionsIsActivated();
-        String path = createPageArea("thresholds", () -> this.threshold.click());
+        String path = createPageArea("thresholds", this.threshold::click);
         return new AdapterThreshold(this, path);
     }
 
@@ -72,7 +72,7 @@ public class Adapter extends PageAreaImpl {
     public AdapterThreshold createThresholdsPageArea(final AdapterThresholdTarget thresholdTarget, final double unhealthyThreshold,
             final double unstableThreshold, final boolean failUnhealthy) {
         ensureAdvancedOptionsIsActivated();
-        String path = createPageArea("thresholds", () -> this.threshold.click());
+        String path = createPageArea("thresholds", this.threshold::click);
         AdapterThreshold adapterThreshold = new AdapterThreshold(this, path);
         adapterThreshold.setThresholdTarget(thresholdTarget);
         adapterThreshold.setUnhealthyThreshold(unhealthyThreshold);

--- a/ui-tests/src/test/java/io/jenkins/plugins/coverage/CoverageReportTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/coverage/CoverageReportTest.java
@@ -55,17 +55,17 @@ public class CoverageReportTest extends UiTest {
         report.open();
 
         FileCoverageTable coverageTable = report.getCoverageTable();
-        CoverageReportTest.verifyFileCoverageTableContent(coverageTable,
+        verifyFileCoverageTableContent(coverageTable,
                 new String[] {"edu.hm.hafner.util", "edu.hm.hafner.util", "edu.hm.hafner.util"},
                 new String[] {"Ensure.java", "FilteredLog.java", "Generated.java"},
                 new String[] {"80.00%", "100.00%", "n/a"},
                 new String[] {"86.96%", "100.00%", "n/a"});
 
         String coverageTree = report.getCoverageTree();
-        CoverageReportTest.verifyCoverageTreeAfterSomeBuildsWithReports(coverageTree);
+        verifyCoverageTreeAfterSomeBuildsWithReports(coverageTree);
 
         String coverageOverview = report.getCoverageOverview();
-        CoverageReportTest.verifyCoverageOverviewAfterSomeBuildsWithReports(coverageOverview);
+        verifyCoverageOverviewAfterSomeBuildsWithReports(coverageOverview);
     }
 
     /**
@@ -80,13 +80,13 @@ public class CoverageReportTest extends UiTest {
         report.open();
 
         FileCoverageTable coverageTable = report.getCoverageTable();
-        CoverageReportTest.verifyFileCoverageTableNumberOfMaxEntries(coverageTable, 307);
+        verifyFileCoverageTableNumberOfMaxEntries(coverageTable, 307);
 
         String coverageTree = report.getCoverageTree();
-        CoverageReportTest.verifyCoverageTreeAfterOneBuildWithReport(coverageTree);
+        verifyCoverageTreeAfterOneBuildWithReport(coverageTree);
 
         String coverageOverview = report.getCoverageOverview();
-        CoverageReportTest.verifyCoverageOverviewAfterOneBuildWithReport(coverageOverview);
+        verifyCoverageOverviewAfterOneBuildWithReport(coverageOverview);
     }
 
     /**
@@ -101,19 +101,19 @@ public class CoverageReportTest extends UiTest {
         report.open();
 
         FileCoverageTable table = report.openFileCoverageTable();
-        CoverageReportTest.verifyFileCoverageTableContent(table,
+        verifyFileCoverageTableContent(table,
                 new String[] {"edu.hm.hafner.analysis", "edu.hm.hafner.analysis", "edu.hm.hafner.analysis"},
                 new String[] {"AbstractPackageDetector.java", "CSharpNamespaceDetector.java", "Categories.java"},
                 new String[] {"88.24%", "100.00%", "100.00%"},
                 new String[] {"50.00%", "n/a", "100.00%"});
         table.openTablePage(2);
-        CoverageReportTest.verifyFileCoverageTableContent(table,
+        verifyFileCoverageTableContent(table,
                 new String[] {"edu.hm.hafner.analysis", "edu.hm.hafner.analysis", "edu.hm.hafner.analysis"},
                 new String[] {"IssueBuilder.java", "IssueDifference.java", "IssueParser.java"},
                 new String[] {"100.00%", "100.00%", "83.33%"},
                 new String[] {"100.00%", "92.86%", "n/a"});
         table.openTablePage(3);
-        CoverageReportTest.verifyFileCoverageTableContent(table,
+        verifyFileCoverageTableContent(table,
                 new String[] {"edu.hm.hafner.analysis", "edu.hm.hafner.analysis", "edu.hm.hafner.analysis"},
                 new String[] {"PackageDetectors.java", "PackageNameResolver.java", "ParsingCanceledException.java"},
                 new String[] {"92.31%", "100.00%", "0.00%"},

--- a/ui-tests/src/test/java/io/jenkins/plugins/coverage/MainPanelTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/coverage/MainPanelTest.java
@@ -22,7 +22,7 @@ public class MainPanelTest extends UiTest {
         FreeStyleJob job = getJobWithFirstBuildAndDifferentReports(InCaseCoverageDecreasedConfiguration.DONT_FAIL);
         buildSuccessfully(job);
         MainPanel mainPanel = new MainPanel(job);
-        MainPanelTest.verifyTrendChartWithTwoReports(mainPanel, 1, 2);
+        verifyTrendChartWithTwoReports(mainPanel, 1, 2);
     }
 
     /**


### PR DESCRIPTION
File nodes are now correctly mapped using the name and path. Additionally, method and class nodes now get a unique ID even when the report does not create one. For this option, the `ignoreErrors` property needs to be activated.

Based on the fix https://github.com/jenkinsci/coverage-model/pull/113.