### PR TITLE
Do not show method coverage in trend by default

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/charts/CoverageSeriesBuilder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/charts/CoverageSeriesBuilder.java
@@ -32,10 +32,15 @@ public class CoverageSeriesBuilder extends SeriesBuilder<CoverageStatistics> {
         add(statistics, Metric.BRANCH, BRANCH_COVERAGE, series);
         add(statistics, Metric.MUTATION, MUTATION_COVERAGE, series);
         add(statistics, Metric.TEST_STRENGTH, TEST_STRENGTH, series);
-        add(statistics, Metric.MCDC_PAIR, MCDC_PAIR_COVERAGE, series);    
-        add(statistics, Metric.FUNCTION_CALL, FUNCTION_CALL_COVERAGE, series);          
-        add(statistics, Metric.METHOD, METHOD_COVERAGE, series);
-                
+        add(statistics, Metric.MCDC_PAIR, MCDC_PAIR_COVERAGE, series);
+        add(statistics, Metric.FUNCTION_CALL, FUNCTION_CALL_COVERAGE, series);
+
+        if (statistics.containsValue(Baseline.PROJECT, Metric.MCDC_PAIR)
+                || statistics.containsValue(Baseline.PROJECT, Metric.FUNCTION_CALL)) {
+            // Method coverage is only relevant if MC/DC pair or function call coverage is available
+            add(statistics, Metric.METHOD, METHOD_COVERAGE, series);
+        }
+
         return series;
     }
 


### PR DESCRIPTION
Due to the changes in #153 the trend chart accidentally shows the method metric.

![Bildschirmfoto 2024-06-28 um 16 34 26](https://github.com/jenkinsci/coverage-plugin/assets/503338/f320a0ec-df75-45b9-8746-4a95fda606a9)

 