### PR TITLE
[JENKINS-75123] Fix inverted logic of `skipSymbolicLinks`

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -494,7 +494,7 @@ public class CoverageRecorder extends Recorder {
 
             try {
                 FileVisitorResult<ModuleNode> result = workspace.act(
-                        new CoverageReportScanner(parser, expandedPattern, "UTF-8", isSkipSymbolicLinks(),
+                        new CoverageReportScanner(parser, expandedPattern, "UTF-8", !isSkipSymbolicLinks(),
                                 ignoreErrors()));
                 log.merge(result.getLog());
 


### PR DESCRIPTION
See [JENKINS-75123](https://issues.jenkins.io/browse/JENKINS-75123).

