### PR TITLE
[JENKINS-75123] Coverage recorder inverts logic for symbolic link following

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -64,17 +64,20 @@ import io.jenkins.plugins.util.RunResultHandler;
 import io.jenkins.plugins.util.ValidationUtilities;
 
 /**
- * A pipeline {@code Step} or Freestyle or Maven {@link Recorder} that reads and parses coverage results in a build and
+ * A pipeline {@code Step} or Freestyle or Maven {@link Recorder} that reads and
+ * parses coverage results in a build and
  * adds the results to the persisted build results.
  *
  * <p>
- * Stores the created issues in a {@link Node}. This result is then attached to the {@link Run build} by registering a
+ * Stores the created issues in a {@link Node}. This result is then attached to
+ * the {@link Run build} by registering a
  * {@link CoverageBuildAction}.
  * </p>
  *
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
+@SuppressWarnings({ "PMD.GodClass", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity",
+        "checkstyle:ClassDataAbstractionCoupling" })
 public class CoverageRecorder extends Recorder {
     static final String CHECKS_DEFAULT_NAME = "Code Coverage";
 
@@ -100,7 +103,7 @@ public class CoverageRecorder extends Recorder {
     private SourceCodeRetention sourceCodeRetention = SourceCodeRetention.LAST_BUILD;
 
     /**
-     * Creates a new instance of {@link  CoverageRecorder}.
+     * Creates a new instance of {@link CoverageRecorder}.
      */
     @DataBoundConstructor
     public CoverageRecorder() {
@@ -113,7 +116,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the coverage tools that will scan files and create coverage reports.
      *
      * @param tools
-     *         the coverage tools
+     *              the coverage tools
      */
     @DataBoundSetter
     public void setTools(final List<CoverageTool> tools) {
@@ -128,7 +131,7 @@ public class CoverageRecorder extends Recorder {
      * Defines the optional list of quality gates.
      *
      * @param qualityGates
-     *         the quality gates
+     *                     the quality gates
      */
     @SuppressWarnings("unused") // used by Stapler view data binding
     @DataBoundSetter
@@ -142,11 +145,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Overrides the default ID of the results. The ID is used as URL of the results and as identifier in UI elements.
+     * Overrides the default ID of the results. The ID is used as URL of the results
+     * and as identifier in UI elements.
      * If no ID is given, then the default ID "coverage".
      *
      * @param id
-     *         the ID of the results
+     *           the ID of the results
      *
      * @see ToolDescriptor#getId()
      */
@@ -162,7 +166,8 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Returns the actual ID of the results. If no user-defined ID is given, then the default ID {@link #DEFAULT_ID} is
+     * Returns the actual ID of the results. If no user-defined ID is given, then
+     * the default ID {@link #DEFAULT_ID} is
      * returned.
      *
      * @return the ID
@@ -173,11 +178,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Overrides the name of the results. The name is used for all labels in the UI. If no name is given, then the
+     * Overrides the name of the results. The name is used for all labels in the UI.
+     * If no name is given, then the
      * default name is used.
      *
      * @param name
-     *         the name of the results
+     *             the name of the results
      *
      * @see #getName()
      */
@@ -194,7 +200,8 @@ public class CoverageRecorder extends Recorder {
      * Sets whether publishing checks should be skipped or not.
      *
      * @param skipPublishingChecks
-     *         {@code true} if publishing checks should be skipped, {@code false} otherwise
+     *                             {@code true} if publishing checks should be
+     *                             skipped, {@code false} otherwise
      */
     @DataBoundSetter
     public void setSkipPublishingChecks(final boolean skipPublishingChecks) {
@@ -209,7 +216,7 @@ public class CoverageRecorder extends Recorder {
      * Changes the default name for the SCM checks report.
      *
      * @param checksName
-     *         the name that should be used for the SCM checks report
+     *                   the name that should be used for the SCM checks report
      */
     @DataBoundSetter
     public void setChecksName(final String checksName) {
@@ -225,7 +232,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the scope of the annotations that should be published to SCM checks.
      *
      * @param checksAnnotationScope
-     *         the scope to use
+     *                              the scope to use
      */
     @DataBoundSetter
     public void setChecksAnnotationScope(final ChecksAnnotationScope checksAnnotationScope) {
@@ -237,10 +244,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Specify if traversal of symbolic links will be skipped during directory scanning for coverage reports.
+     * Specify if traversal of symbolic links will be skipped during directory
+     * scanning for coverage reports.
      *
      * @param skipSymbolicLinks
-     *         if symbolic links should be skipped during directory scanning
+     *                          if symbolic links should be skipped during directory
+     *                          scanning
      */
     @DataBoundSetter
     public void setSkipSymbolicLinks(final boolean skipSymbolicLinks) {
@@ -252,10 +261,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Specify if parsing errors should be ignored and logged instead of throwing an exception.
+     * Specify if parsing errors should be ignored and logged instead of throwing an
+     * exception.
      *
      * @param ignoreParsingErrors
-     *         if parsing errors should be ignored and logged instead of throwing an exception
+     *                            if parsing errors should be ignored and logged
+     *                            instead of throwing an exception
      */
     @DataBoundSetter
     public void setIgnoreParsingErrors(final boolean ignoreParsingErrors) {
@@ -267,11 +278,13 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Determines whether to fail the build on errors during the step of recording coverage reports.
+     * Determines whether to fail the build on errors during the step of recording
+     * coverage reports.
      *
      * @param failOnError
-     *         if {@code true} then the build will be failed on errors, {@code false} then errors are only reported in
-     *         the UI
+     *                    if {@code true} then the build will be failed on errors,
+     *                    {@code false} then errors are only reported in
+     *                    the UI
      */
     @DataBoundSetter
     @SuppressWarnings("unused") // Used by Stapler
@@ -287,8 +300,9 @@ public class CoverageRecorder extends Recorder {
      * Returns whether recording should be enabled for failed builds as well.
      *
      * @param enabledForFailure
-     *         {@code true} if recording should be enabled for failed builds as well, {@code false} if recording is
-     *         enabled for successful or unstable builds only
+     *                          {@code true} if recording should be enabled for
+     *                          failed builds as well, {@code false} if recording is
+     *                          enabled for successful or unstable builds only
      */
     @DataBoundSetter
     public void setEnabledForFailure(final boolean enabledForFailure) {
@@ -303,7 +317,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the encoding to use to read source files.
      *
      * @param sourceCodeEncoding
-     *         the encoding, e.g. "ISO-8859-1"
+     *                           the encoding, e.g. "ISO-8859-1"
      */
     @DataBoundSetter
     public void setSourceCodeEncoding(final String sourceCodeEncoding) {
@@ -315,12 +329,14 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Sets the paths to the directories that contain the source code. If not relative and thus not part of the
-     * workspace, then these directories need to be added in Jenkins global configuration to prevent accessing of
+     * Sets the paths to the directories that contain the source code. If not
+     * relative and thus not part of the
+     * workspace, then these directories need to be added in Jenkins global
+     * configuration to prevent accessing of
      * forbidden resources.
      *
      * @param sourceCodeDirectories
-     *         directories containing the source code
+     *                              directories containing the source code
      */
     @DataBoundSetter
     public void setSourceDirectories(final List<SourceCodeDirectory> sourceCodeDirectories) {
@@ -343,7 +359,7 @@ public class CoverageRecorder extends Recorder {
      * Defines the retention strategy for source code files.
      *
      * @param sourceCodeRetention
-     *         the retention strategy for source code files
+     *                            the retention strategy for source code files
      */
     @DataBoundSetter
     public void setSourceCodeRetention(final SourceCodeRetention sourceCodeRetention) {
@@ -355,11 +371,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Sets the SCM that should be used to find the reference build for. The reference recorder will select the SCM
+     * Sets the SCM that should be used to find the reference build for. The
+     * reference recorder will select the SCM
      * based on a substring comparison, there is no need to specify the full name.
      *
      * @param scm
-     *         the ID of the SCM to use (a substring of the full ID)
+     *            the ID of the SCM to use (a substring of the full ID)
      */
     @DataBoundSetter
     public void setScm(final String scm) {
@@ -403,18 +420,17 @@ public class CoverageRecorder extends Recorder {
             if (tools.isEmpty()) {
                 failStage(resultHandler, logHandler, log,
                         "No tools defined that will record the coverage files");
-            }
-            else {
+            } else {
                 perform(run, workspace, taskListener, resultHandler, log, logHandler);
             }
-        }
-        else {
+        } else {
             logHandler.log("Skipping execution of coverage recorder since overall result is '%s'", overallResult);
         }
     }
 
     private void perform(final Run<?, ?> run, final FilePath workspace, final TaskListener taskListener,
-            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
+            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler)
+            throws InterruptedException {
         var results = recordCoverageResults(run, workspace, resultHandler, log, logHandler);
         Node aggregatedResult = aggregateResults(log, results);
 
@@ -432,7 +448,8 @@ public class CoverageRecorder extends Recorder {
                     getSourceCodeEncoding(), getSourceCodeRetention(), resultHandler, log);
 
             if (!skipPublishingChecks) {
-                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(), getChecksAnnotationScope());
+                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(),
+                        getChecksAnnotationScope());
                 checksPublisher.publishCoverageReport(taskListener);
             }
         }
@@ -478,7 +495,8 @@ public class CoverageRecorder extends Recorder {
     }
 
     private Map<Parser, List<ModuleNode>> recordCoverageResults(final Run<?, ?> run, final FilePath workspace,
-            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
+            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler)
+            throws InterruptedException {
         Map<Parser, List<ModuleNode>> results = new EnumMap<>(Parser.class);
 
         for (CoverageTool tool : tools) {
@@ -506,14 +524,12 @@ public class CoverageRecorder extends Recorder {
                         var errorMessage = "Failing build due to some errors during recording of the coverage";
                         log.logInfo(errorMessage);
                         resultHandler.publishResult(Result.FAILURE, errorMessage);
-                    }
-                    else {
+                    } else {
                         log.logInfo("Ignore errors and continue processing");
                     }
                 }
                 results.put(tool.getParser(), coverageResults);
-            }
-            catch (IOException exception) {
+            } catch (IOException exception) {
                 log.logException(exception, "Exception while parsing with tool " + tool);
             }
 
@@ -528,8 +544,7 @@ public class CoverageRecorder extends Recorder {
             log.logError("No coverage results were found! Configuration error?");
 
             return new ModuleNode("Empty");
-        }
-        else {
+        } else {
             var testCases = results.entrySet()
                     .stream()
                     .filter(entry -> entry.getKey().getParserType() == ParserType.TEST)
@@ -603,8 +618,7 @@ public class CoverageRecorder extends Recorder {
 
             return environmentResolver.expandEnvironmentVariables(
                     run.getEnvironment(TaskListener.NULL), actualPattern);
-        }
-        catch (IOException | InterruptedException ignore) {
+        } catch (IOException | InterruptedException ignore) {
             return actualPattern; // fallback, no expansion
         }
     }
@@ -679,9 +693,9 @@ public class CoverageRecorder extends Recorder {
          * Performs on-the-fly validation on the character encoding.
          *
          * @param project
-         *         the project that is configured
+         *                           the project that is configured
          * @param sourceCodeEncoding
-         *         the character encoding
+         *                           the character encoding
          *
          * @return the validation result
          */
@@ -700,9 +714,9 @@ public class CoverageRecorder extends Recorder {
          * Performs on-the-fly validation of the ID.
          *
          * @param project
-         *         the project that is configured
+         *                the project that is configured
          * @param id
-         *         the ID of the tool
+         *                the ID of the tool
          *
          * @return the validation result
          */

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -64,20 +64,17 @@ import io.jenkins.plugins.util.RunResultHandler;
 import io.jenkins.plugins.util.ValidationUtilities;
 
 /**
- * A pipeline {@code Step} or Freestyle or Maven {@link Recorder} that reads and
- * parses coverage results in a build and
+ * A pipeline {@code Step} or Freestyle or Maven {@link Recorder} that reads and parses coverage results in a build and
  * adds the results to the persisted build results.
  *
  * <p>
- * Stores the created issues in a {@link Node}. This result is then attached to
- * the {@link Run build} by registering a
+ * Stores the created issues in a {@link Node}. This result is then attached to the {@link Run build} by registering a
  * {@link CoverageBuildAction}.
  * </p>
  *
  * @author Ullrich Hafner
  */
-@SuppressWarnings({ "PMD.GodClass", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity",
-        "checkstyle:ClassDataAbstractionCoupling" })
+@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public class CoverageRecorder extends Recorder {
     static final String CHECKS_DEFAULT_NAME = "Code Coverage";
 
@@ -103,7 +100,7 @@ public class CoverageRecorder extends Recorder {
     private SourceCodeRetention sourceCodeRetention = SourceCodeRetention.LAST_BUILD;
 
     /**
-     * Creates a new instance of {@link CoverageRecorder}.
+     * Creates a new instance of {@link  CoverageRecorder}.
      */
     @DataBoundConstructor
     public CoverageRecorder() {
@@ -116,7 +113,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the coverage tools that will scan files and create coverage reports.
      *
      * @param tools
-     *              the coverage tools
+     *         the coverage tools
      */
     @DataBoundSetter
     public void setTools(final List<CoverageTool> tools) {
@@ -131,7 +128,7 @@ public class CoverageRecorder extends Recorder {
      * Defines the optional list of quality gates.
      *
      * @param qualityGates
-     *                     the quality gates
+     *         the quality gates
      */
     @SuppressWarnings("unused") // used by Stapler view data binding
     @DataBoundSetter
@@ -145,12 +142,11 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Overrides the default ID of the results. The ID is used as URL of the results
-     * and as identifier in UI elements.
+     * Overrides the default ID of the results. The ID is used as URL of the results and as identifier in UI elements.
      * If no ID is given, then the default ID "coverage".
      *
      * @param id
-     *           the ID of the results
+     *         the ID of the results
      *
      * @see ToolDescriptor#getId()
      */
@@ -166,8 +162,7 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Returns the actual ID of the results. If no user-defined ID is given, then
-     * the default ID {@link #DEFAULT_ID} is
+     * Returns the actual ID of the results. If no user-defined ID is given, then the default ID {@link #DEFAULT_ID} is
      * returned.
      *
      * @return the ID
@@ -178,12 +173,11 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Overrides the name of the results. The name is used for all labels in the UI.
-     * If no name is given, then the
+     * Overrides the name of the results. The name is used for all labels in the UI. If no name is given, then the
      * default name is used.
      *
      * @param name
-     *             the name of the results
+     *         the name of the results
      *
      * @see #getName()
      */
@@ -200,8 +194,7 @@ public class CoverageRecorder extends Recorder {
      * Sets whether publishing checks should be skipped or not.
      *
      * @param skipPublishingChecks
-     *                             {@code true} if publishing checks should be
-     *                             skipped, {@code false} otherwise
+     *         {@code true} if publishing checks should be skipped, {@code false} otherwise
      */
     @DataBoundSetter
     public void setSkipPublishingChecks(final boolean skipPublishingChecks) {
@@ -216,7 +209,7 @@ public class CoverageRecorder extends Recorder {
      * Changes the default name for the SCM checks report.
      *
      * @param checksName
-     *                   the name that should be used for the SCM checks report
+     *         the name that should be used for the SCM checks report
      */
     @DataBoundSetter
     public void setChecksName(final String checksName) {
@@ -232,7 +225,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the scope of the annotations that should be published to SCM checks.
      *
      * @param checksAnnotationScope
-     *                              the scope to use
+     *         the scope to use
      */
     @DataBoundSetter
     public void setChecksAnnotationScope(final ChecksAnnotationScope checksAnnotationScope) {
@@ -244,12 +237,10 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Specify if traversal of symbolic links will be skipped during directory
-     * scanning for coverage reports.
+     * Specify if traversal of symbolic links will be skipped during directory scanning for coverage reports.
      *
      * @param skipSymbolicLinks
-     *                          if symbolic links should be skipped during directory
-     *                          scanning
+     *         if symbolic links should be skipped during directory scanning
      */
     @DataBoundSetter
     public void setSkipSymbolicLinks(final boolean skipSymbolicLinks) {
@@ -261,12 +252,10 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Specify if parsing errors should be ignored and logged instead of throwing an
-     * exception.
+     * Specify if parsing errors should be ignored and logged instead of throwing an exception.
      *
      * @param ignoreParsingErrors
-     *                            if parsing errors should be ignored and logged
-     *                            instead of throwing an exception
+     *         if parsing errors should be ignored and logged instead of throwing an exception
      */
     @DataBoundSetter
     public void setIgnoreParsingErrors(final boolean ignoreParsingErrors) {
@@ -278,13 +267,11 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Determines whether to fail the build on errors during the step of recording
-     * coverage reports.
+     * Determines whether to fail the build on errors during the step of recording coverage reports.
      *
      * @param failOnError
-     *                    if {@code true} then the build will be failed on errors,
-     *                    {@code false} then errors are only reported in
-     *                    the UI
+     *         if {@code true} then the build will be failed on errors, {@code false} then errors are only reported in
+     *         the UI
      */
     @DataBoundSetter
     @SuppressWarnings("unused") // Used by Stapler
@@ -300,9 +287,8 @@ public class CoverageRecorder extends Recorder {
      * Returns whether recording should be enabled for failed builds as well.
      *
      * @param enabledForFailure
-     *                          {@code true} if recording should be enabled for
-     *                          failed builds as well, {@code false} if recording is
-     *                          enabled for successful or unstable builds only
+     *         {@code true} if recording should be enabled for failed builds as well, {@code false} if recording is
+     *         enabled for successful or unstable builds only
      */
     @DataBoundSetter
     public void setEnabledForFailure(final boolean enabledForFailure) {
@@ -317,7 +303,7 @@ public class CoverageRecorder extends Recorder {
      * Sets the encoding to use to read source files.
      *
      * @param sourceCodeEncoding
-     *                           the encoding, e.g. "ISO-8859-1"
+     *         the encoding, e.g. "ISO-8859-1"
      */
     @DataBoundSetter
     public void setSourceCodeEncoding(final String sourceCodeEncoding) {
@@ -329,14 +315,12 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Sets the paths to the directories that contain the source code. If not
-     * relative and thus not part of the
-     * workspace, then these directories need to be added in Jenkins global
-     * configuration to prevent accessing of
+     * Sets the paths to the directories that contain the source code. If not relative and thus not part of the
+     * workspace, then these directories need to be added in Jenkins global configuration to prevent accessing of
      * forbidden resources.
      *
      * @param sourceCodeDirectories
-     *                              directories containing the source code
+     *         directories containing the source code
      */
     @DataBoundSetter
     public void setSourceDirectories(final List<SourceCodeDirectory> sourceCodeDirectories) {
@@ -359,7 +343,7 @@ public class CoverageRecorder extends Recorder {
      * Defines the retention strategy for source code files.
      *
      * @param sourceCodeRetention
-     *                            the retention strategy for source code files
+     *         the retention strategy for source code files
      */
     @DataBoundSetter
     public void setSourceCodeRetention(final SourceCodeRetention sourceCodeRetention) {
@@ -371,12 +355,11 @@ public class CoverageRecorder extends Recorder {
     }
 
     /**
-     * Sets the SCM that should be used to find the reference build for. The
-     * reference recorder will select the SCM
+     * Sets the SCM that should be used to find the reference build for. The reference recorder will select the SCM
      * based on a substring comparison, there is no need to specify the full name.
      *
      * @param scm
-     *            the ID of the SCM to use (a substring of the full ID)
+     *         the ID of the SCM to use (a substring of the full ID)
      */
     @DataBoundSetter
     public void setScm(final String scm) {
@@ -395,7 +378,7 @@ public class CoverageRecorder extends Recorder {
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
             throws InterruptedException, IOException {
-        FilePath workspace = build.getWorkspace();
+        var workspace = build.getWorkspace();
         if (workspace == null) {
             throw new IOException("No workspace found for " + build);
         }
@@ -407,10 +390,10 @@ public class CoverageRecorder extends Recorder {
 
     void perform(final Run<?, ?> run, final FilePath workspace, final TaskListener taskListener,
             final ResultHandler resultHandler) throws InterruptedException {
-        Result overallResult = run.getResult();
-        LogHandler logHandler = new LogHandler(taskListener, "Coverage");
+        var overallResult = run.getResult();
+        var logHandler = new LogHandler(taskListener, "Coverage");
         if (enabledForFailure || overallResult == null || overallResult.isBetterOrEqualTo(Result.UNSTABLE)) {
-            FilteredLog log = new FilteredLog("Errors while recording code coverage:");
+            var log = new FilteredLog("Errors while recording code coverage:");
             log.logInfo("Recording coverage results");
 
             var validation = VALIDATION_UTILITIES.validateId(getId());
@@ -420,22 +403,23 @@ public class CoverageRecorder extends Recorder {
             if (tools.isEmpty()) {
                 failStage(resultHandler, logHandler, log,
                         "No tools defined that will record the coverage files");
-            } else {
+            }
+            else {
                 perform(run, workspace, taskListener, resultHandler, log, logHandler);
             }
-        } else {
+        }
+        else {
             logHandler.log("Skipping execution of coverage recorder since overall result is '%s'", overallResult);
         }
     }
 
     private void perform(final Run<?, ?> run, final FilePath workspace, final TaskListener taskListener,
-            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler)
-            throws InterruptedException {
+            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
         var results = recordCoverageResults(run, workspace, resultHandler, log, logHandler);
-        Node aggregatedResult = aggregateResults(log, results);
+        var aggregatedResult = aggregateResults(log, results);
 
         if (!aggregatedResult.isEmpty()) {
-            CoverageReporter reporter = new CoverageReporter();
+            var reporter = new CoverageReporter();
 
             var sources = aggregatedResult.getSourceFolders();
             sources.addAll(getSourceDirectoriesPaths());
@@ -448,8 +432,7 @@ public class CoverageRecorder extends Recorder {
                     getSourceCodeEncoding(), getSourceCodeRetention(), resultHandler, log);
 
             if (!skipPublishingChecks) {
-                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(),
-                        getChecksAnnotationScope());
+                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(), getChecksAnnotationScope());
                 checksPublisher.publishCoverageReport(taskListener);
             }
         }
@@ -465,7 +448,7 @@ public class CoverageRecorder extends Recorder {
             log.logInfo("Making paths of " + pathMapping.size() + " source code files relative to workspace root...");
             var builder = new TreeStringBuilder();
             rootNode.getAllFileNodes().forEach(file -> {
-                String relativePath = file.getRelativePath();
+                var relativePath = file.getRelativePath();
                 if (pathMapping.containsKey(relativePath)) {
                     file.setRelativePath(builder.intern(pathMapping.get(relativePath)));
                 }
@@ -495,19 +478,18 @@ public class CoverageRecorder extends Recorder {
     }
 
     private Map<Parser, List<ModuleNode>> recordCoverageResults(final Run<?, ?> run, final FilePath workspace,
-            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler)
-            throws InterruptedException {
+            final ResultHandler resultHandler, final FilteredLog log, final LogHandler logHandler) throws InterruptedException {
         Map<Parser, List<ModuleNode>> results = new EnumMap<>(Parser.class);
 
         for (CoverageTool tool : tools) {
-            Parser parser = tool.getParser();
+            var parser = tool.getParser();
             log.logInfo("Creating parser for %s", tool.getDisplayName());
             if (StringUtils.isBlank(tool.getPattern())) {
                 log.logInfo("Using default pattern '%s' since user defined pattern is not set",
                         parser.getDefaultPattern());
             }
 
-            String expandedPattern = expandPattern(run, tool.getActualPattern());
+            var expandedPattern = expandPattern(run, tool.getActualPattern());
             if (!expandedPattern.equals(tool.getActualPattern())) {
                 log.logInfo("Expanding pattern '%s' to '%s'", tool.getActualPattern(), expandedPattern);
             }
@@ -524,12 +506,14 @@ public class CoverageRecorder extends Recorder {
                         var errorMessage = "Failing build due to some errors during recording of the coverage";
                         log.logInfo(errorMessage);
                         resultHandler.publishResult(Result.FAILURE, errorMessage);
-                    } else {
+                    }
+                    else {
                         log.logInfo("Ignore errors and continue processing");
                     }
                 }
                 results.put(tool.getParser(), coverageResults);
-            } catch (IOException exception) {
+            }
+            catch (IOException exception) {
                 log.logException(exception, "Exception while parsing with tool " + tool);
             }
 
@@ -544,7 +528,8 @@ public class CoverageRecorder extends Recorder {
             log.logError("No coverage results were found! Configuration error?");
 
             return new ModuleNode("Empty");
-        } else {
+        }
+        else {
             var testCases = results.entrySet()
                     .stream()
                     .filter(entry -> entry.getKey().getParserType() == ParserType.TEST)
@@ -614,11 +599,12 @@ public class CoverageRecorder extends Recorder {
 
     private String expandPattern(final Run<?, ?> run, final String actualPattern) {
         try {
-            EnvironmentResolver environmentResolver = new EnvironmentResolver();
+            var environmentResolver = new EnvironmentResolver();
 
             return environmentResolver.expandEnvironmentVariables(
                     run.getEnvironment(TaskListener.NULL), actualPattern);
-        } catch (IOException | InterruptedException ignore) {
+        }
+        catch (IOException | InterruptedException ignore) {
             return actualPattern; // fallback, no expansion
         }
     }
@@ -693,9 +679,9 @@ public class CoverageRecorder extends Recorder {
          * Performs on-the-fly validation on the character encoding.
          *
          * @param project
-         *                           the project that is configured
+         *         the project that is configured
          * @param sourceCodeEncoding
-         *                           the character encoding
+         *         the character encoding
          *
          * @return the validation result
          */
@@ -714,9 +700,9 @@ public class CoverageRecorder extends Recorder {
          * Performs on-the-fly validation of the ID.
          *
          * @param project
-         *                the project that is configured
+         *         the project that is configured
          * @param id
-         *                the ID of the tool
+         *         the ID of the tool
          *
          * @return the validation result
          */
@@ -743,7 +729,7 @@ public class CoverageRecorder extends Recorder {
         ALL_LINES;
 
         static ListBoxModel fillItems() {
-            ListBoxModel items = new ListBoxModel();
+            var items = new ListBoxModel();
             items.add(Messages.ChecksAnnotationScope_Skip(), SKIP.name());
             items.add(Messages.ChecksAnnotationScope_ModifiedLines(), MODIFIED_LINES.name());
             items.add(Messages.ChecksAnnotationScope_AllLines(), ALL_LINES.name());

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorderTest.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.coverage.metrics.steps;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CoverageRecorderTest {
+
+    @Test
+    void shouldPassCorrectSymbolicLinksValue() {
+        // When skipSymbolicLinks is true, followSymbolicLinks should be false
+        CoverageRecorder recorder = new CoverageRecorder();
+        recorder.setSkipSymbolicLinks(true);
+        assertThat(recorder.isSkipSymbolicLinks()).isTrue();
+        assertThat(!recorder.isSkipSymbolicLinks()).isFalse(); // This is what's passed to CoverageReportScanner
+
+        // When skipSymbolicLinks is false, followSymbolicLinks should be true
+        recorder.setSkipSymbolicLinks(false);
+        assertThat(recorder.isSkipSymbolicLinks()).isFalse();
+        assertThat(!recorder.isSkipSymbolicLinks()).isTrue(); // This is what's passed to CoverageReportScanner
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-75123](https://issues.jenkins.io/browse/JENKINS-75123?jql=labels%20%3D%20newbie-friendly)
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
