### PR TITLE
[FIXES JENKINS-72398] passes missing symbols ampersand, lt, gt

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
@@ -28,6 +28,9 @@ class CoverageSourcePrinter implements Serializable {
     static final String FULL_COVERAGE = "coverFull";
     static final String PARTIAL_COVERAGE = "coverPart";
     static final String NBSP = "&nbsp;";
+    static final String LT = "&lt;";
+    static final String GT = "&gt;";
+    static final String AMP = "&amp;";
 
     private final String path;
     private final int[] linesToPaint;
@@ -64,6 +67,9 @@ class CoverageSourcePrinter implements Serializable {
     protected String cleanupCode(final String content) {
         return content.replace("\n", StringUtils.EMPTY)
                 .replace("\r", StringUtils.EMPTY)
+                .replace("&", AMP)
+                .replace("<", LT)
+                .replace(">", GT)
                 .replace(" ", NBSP)
                 .replace("\t", NBSP.repeat(8));
     }


### PR DESCRIPTION
This change passes missing symbols ampersand, less-than, greater-than.
This is to allow better presentation of C++ code.

https://issues.jenkins.io/browse/JENKINS-72398

It turns characters ampersand, less-than, greater-than into their respective  html (sgml) entities `&amp;`  `&lt;`  `&gt;` .
It is the minimal change as discussed in the JIRA ticket [JENKINS-72398]
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
