### PR TITLE
Remove column right alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node
 node_modules
 target
+work
 *.iml
 .classpath
 .project

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/column.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/column.jelly
@@ -8,7 +8,7 @@
   <j:choose>
     <j:when test="${coverageValue.isPresent()}">
 
-      <td align="right">
+      <td>
         <j:set var="tooltip">
           <j:set var="baseline" value="${it.baseline}"/>
           <!-- This is an exact copy of the tooltip in coverage-summary.jelly -->
@@ -74,7 +74,7 @@
       </td>
     </j:when>
     <j:otherwise>
-      <td align="right">
+      <td>
         ${coverageText}
       </td>
     </j:otherwise>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/columnHeader.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/columnHeader.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <th align="right">${it.columnName}</th>
+    <th>${it.columnName}</th>
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/Messages.properties
@@ -12,7 +12,7 @@ Parser.PIT=PIT Mutation Testing Reports
 Parser.VectorCAST=VectorCAST Coverage Results
 Parser.Xunit=XUnit Test Results
 
-Coverage.Not.Available=n/a
+Coverage.Not.Available=N/A
 Coverage.Link.Name=Coverage Report
 Coverage.Trend.Name={0} Trend
 Coverage.Trend.Default.Name=Code Coverage Trend


### PR DESCRIPTION
This change removes the "right" alignment of the metric column. Using the default alignment appears more consistent with other default columns. When the coverage column is not the last column right alignment can add a wide gap due
to the different alignments.

Another minor change updates the coverage not available text to be "N/A" to match the value used by Jenkins core.

_Before_
<img width="2154" height="384" alt="Screenshot 2025-08-01 at 11 25 39 PM" src="https://github.com/user-attachments/assets/c42e2c72-04da-42e4-b7bb-333b9e9eda58" />
_After_
<img width="2164" height="406" alt="Screenshot 2025-08-01 at 11 22 25 PM" src="https://github.com/user-attachments/assets/2836a276-563f-4329-8ed9-505119938ae0" />
_Before_
<img width="3070" height="326" alt="Screenshot 2025-08-01 at 11 31 13 PM" src="https://github.com/user-attachments/assets/dec3583e-06e2-421f-92e0-3acb378c7ed8" />
_After_
<img width="3070" height="326" alt="Screenshot 2025-08-01 at 11 30 25 PM" src="https://github.com/user-attachments/assets/3cc1074e-5e88-44e0-a883-af73f9fadb66" />
_Before_
<img width="3070" height="326" alt="Screenshot 2025-08-01 at 11 29 30 PM" src="https://github.com/user-attachments/assets/df92e7cf-f000-4fa8-9583-3574a9efa72e" />
_After_
<img width="3070" height="326" alt="Screenshot 2025-08-01 at 11 29 49 PM" src="https://github.com/user-attachments/assets/8177ca79-9ecf-470c-9f34-2a6530c84b22" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
