### PR TITLE
Add option to disable coverage column by default

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
@@ -1,11 +1,12 @@
 package io.jenkins.plugins.coverage.metrics;
 
+import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.util.GlobalConfigurationItem;
 import jenkins.appearance.AppearanceCategory;
-import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,7 +17,7 @@ import org.kohsuke.stapler.DataBoundSetter;
  */
 @Extension
 @Symbol("coverage")
-public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
+public class CoverageAppearanceGlobalConfiguration extends GlobalConfigurationItem {
     private boolean enableColumnByDefault = true;
 
     /**
@@ -32,11 +33,20 @@ public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
     /**
      * Create global coverage appearance configuration.
      */
-    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
-    @SuppressFBWarnings(value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", justification = "GlobalConfiguration instructs subclasses to call load()")
+    @SuppressWarnings("unused")
     @DataBoundConstructor
     public CoverageAppearanceGlobalConfiguration() {
         super();
+        load();
+    }
+
+    /**
+     * Constructor for unit testing.
+     * @param facade global configuration facade
+     */
+    @VisibleForTesting
+    CoverageAppearanceGlobalConfiguration(final GlobalConfigurationFacade facade) {
+        super(facade);
         load();
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
@@ -1,0 +1,60 @@
+package io.jenkins.plugins.coverage.metrics;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import jenkins.appearance.AppearanceCategory;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Global appearance configuration for Coverage Metrics.
+ */
+@Extension
+@Symbol("coverage")
+public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
+
+    private boolean enableColumnByDefault;
+
+    /**
+     * Get global configuration instance.
+     * @return global configuration
+     * @throws IllegalStateException if configuration not available
+     */
+    @NonNull
+    public static CoverageAppearanceGlobalConfiguration get() {
+        return ExtensionList.lookupSingleton(CoverageAppearanceGlobalConfiguration.class);
+    }
+
+    @DataBoundConstructor
+    public CoverageAppearanceGlobalConfiguration() {
+        load();
+    }
+
+    @NonNull
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(AppearanceCategory.class);
+    }
+
+    /**
+     * Is the metric column enabled by default.
+     * @return {@code true} if coverage metric column should be displayed by default
+     */
+    public boolean isEnableColumnByDefault() {
+        return enableColumnByDefault;
+    }
+
+    /**
+     * Enable/disable metric column display by default.
+     * @param enableColumnByDefault {@code true} to enable metric column by default.
+     */
+    @DataBoundSetter
+    public void setEnableColumnByDefault(boolean enableColumnByDefault) {
+        this.enableColumnByDefault = enableColumnByDefault;
+        save();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
@@ -16,8 +16,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 @Extension
 @Symbol("coverage")
 public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
-
-    private boolean enableColumnByDefault;
+    private boolean enableColumnByDefault = true;
 
     /**
      * Get global configuration instance.
@@ -29,6 +28,9 @@ public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
         return ExtensionList.lookupSingleton(CoverageAppearanceGlobalConfiguration.class);
     }
 
+    /**
+     * Create global coverage appearance configuration.
+     */
     @DataBoundConstructor
     public CoverageAppearanceGlobalConfiguration() {
         load();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.coverage.metrics;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import jenkins.appearance.AppearanceCategory;
@@ -31,8 +32,11 @@ public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
     /**
      * Create global coverage appearance configuration.
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
+    @SuppressFBWarnings(value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", justification = "GlobalConfiguration instructs subclasses to call load()")
     @DataBoundConstructor
     public CoverageAppearanceGlobalConfiguration() {
+        super();
         load();
     }
 
@@ -54,8 +58,9 @@ public class CoverageAppearanceGlobalConfiguration extends GlobalConfiguration {
      * Enable/disable metric column display by default.
      * @param enableColumnByDefault {@code true} to enable metric column by default.
      */
+    @SuppressWarnings("unused") // Called by jelly view
     @DataBoundSetter
-    public void setEnableColumnByDefault(boolean enableColumnByDefault) {
+    public void setEnableColumnByDefault(final boolean enableColumnByDefault) {
         this.enableColumnByDefault = enableColumnByDefault;
         save();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Optional;
 
+import io.jenkins.plugins.coverage.metrics.CoverageAppearanceGlobalConfiguration;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.verb.POST;
@@ -258,6 +259,11 @@ public class CoverageMetricColumn extends ListViewColumn {
         @Override
         public String getDisplayName() {
             return Messages.Coverage_Column();
+        }
+
+        @Override
+        public boolean shownByDefault() {
+            return CoverageAppearanceGlobalConfiguration.get().isEnableColumnByDefault();
         }
 
         /**

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Coverage Metrics}">
+        <f:entry field="enableColumnByDefault" title="${%Display Coverage column by default}">
+            <f:checkbox />
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:section title="${%Coverage Metrics}">
+    <f:section title="${%Coverage plugin appearance}">
         <f:entry field="enableColumnByDefault" title="${%Display coverage column in 'All View' by default}">
             <f:checkbox />
         </f:entry>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Coverage Metrics}">
-        <f:entry field="enableColumnByDefault" title="${%Display Coverage column by default}">
+        <f:entry field="enableColumnByDefault" title="${%Display coverage column in 'All View' by default}">
             <f:checkbox />
         </f:entry>
     </f:section>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/help-enableColumnByDefault.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/help-enableColumnByDefault.html
@@ -1,0 +1,2 @@
+Show the "Coverage" metric column in views by default. When enabled the column will be displayed in the default "all" view
+and included in newly created list views.

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/help-enableColumnByDefault.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfiguration/help-enableColumnByDefault.html
@@ -1,2 +1,2 @@
-Show the "Coverage" metric column in views by default. When enabled the column will be displayed in the default "all" view
+Show the "Coverage" column in the "All View" by default. The "All View" cannot be configured by users, so this option provides a way to enable or disable the coverage column for all users globally.
 and included in newly created list views.

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/CoverageAppearanceGlobalConfigurationTest.java
@@ -1,0 +1,34 @@
+package io.jenkins.plugins.coverage.metrics;
+
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for {@link CoverageAppearanceGlobalConfiguration}.
+ */
+class CoverageAppearanceGlobalConfigurationTest {
+    private CoverageAppearanceGlobalConfiguration configuration;
+    private GlobalConfigurationFacade globalConfigurationFacade;
+
+    @BeforeEach
+    void setup() {
+        globalConfigurationFacade = mock(GlobalConfigurationFacade.class);
+        configuration = new CoverageAppearanceGlobalConfiguration(globalConfigurationFacade);
+    }
+
+    @Test
+    void shouldInitializeThemes() {
+        assertThat(configuration.isEnableColumnByDefault()).isTrue();
+        configuration.setEnableColumnByDefault(false);
+        assertThat(configuration.isEnableColumnByDefault()).isFalse();
+        InOrder inOrder = inOrder(globalConfigurationFacade);
+        inOrder.verify(globalConfigurationFacade).load();
+        inOrder.verify(globalConfigurationFacade).save();
+        inOrder.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
This change adds global appearance configuration to disable coverage column from showing by default.

The maven pipeline integration plugin now has a dependency on this plugin which automatically adds the coverage column which will always be "n/a" for projects that don't generate or record coverage reports. This isn't a problem for custom views, but the default "all" view includes all default columns and can't be configured other wise. This change allows users to remove the column from this view.

<img width="2862" height="1046" alt="Screenshot 2025-08-01 at 11 23 44 PM" src="https://github.com/user-attachments/assets/fcd39048-0c0b-4fe5-a87a-7a391ff5d1b9" />

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
