### PR TITLE
Use Jenkins cards in all views

### DIFF
--- a/plugin/src/main/resources/coverage/coverage-table.jelly
+++ b/plugin/src/main/resources/coverage/coverage-table.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:bs="/bootstrap5" xmlns:dt="/data-tables" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:dt="/data-tables" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome"
+         xmlns:f="/lib/form" xmlns:l="/lib/layout">
 
   <st:documentation>
     Provides a table to render the file coverage nodes without the source code.
@@ -23,58 +24,65 @@
     <j:choose>
       <j:when test="${it.hasSourceCode()}">
         <div class="col-12 d-xxl-none">
-          <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100" >
-            <dt:table model="${it.getTableModel(id + '-table')}">
-              <j:if test="${showChangedToggle}">
-                <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}" />
-              </j:if>
-            </dt:table>
-          </bs:card>
+          <l:card title="${title}" >
+            <div class="flex-fill h-100">
+              <dt:table model="${it.getTableModel(id + '-table')}">
+                <j:if test="${showChangedToggle}">
+                  <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}" />
+                </j:if>
+              </dt:table>
+            </div>
+          </l:card>
         </div>
         <div class="col-xxl-6 d-none d-xxl-block">
-          <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100">
-            <dt:table model="${it.getTableModel(id + '-table-inline')}">
-              <j:if test="${showChangedToggle}">
-                <f:toggleSwitch id="changed-${id + '-table-inline'}" title="${%changed.files}" />
-              </j:if>
-            </dt:table>
-          </bs:card>
+          <l:card title="${title}">
+            <div class="flex-fill h-100">
+              <dt:table model="${it.getTableModel(id + '-table-inline')}">
+                <j:if test="${showChangedToggle}">
+                  <f:toggleSwitch id="changed-${id + '-table-inline'}" title="${%changed.files}" />
+                </j:if>
+              </dt:table>
+            </div>
+          </l:card>
         </div>
         <div class="col-xxl-6 d-none d-xxl-block">
-          <bs:card title="${%Source code view}" symbol="symbol-regular/file-code plugin-font-awesome-api"
-                   class="flex-fill h-100">
-            <div id="${id}-source-file-content">
-              <table id="${id}-source-file" class="source">
-              </table>
+          <l:card title="${%Source code view}">
+            <div class="flex-fill h-100">
+              <div id="${id}-source-file-content">
+                <table id="${id}-source-file" class="source">
+                </table>
+              </div>
+              <div id="${id}-no-selection">
+                <div class="text-center">
+                  <fa:svg-icon name="hand-point-left" class="no-selection-banner"/>
+                </div>
+                <div class="text-center">
+                  <h5 class="card-title">${%select.row}</h5>
+                </div>
+              </div>
+              <div id="${id}-no-source">
+                <div class="text-center">
+                  <fa:svg-icon name="ban" class="no-selection-banner"/>
+                </div>
+                <div class="text-center">
+                  <h5 class="card-title">${%no.sourcecode}</h5>
+                </div>
+              </div>
             </div>
-            <div id="${id}-no-selection">
-              <div class="text-center">
-                <fa:svg-icon name="hand-point-left" class="no-selection-banner"/>
-              </div>
-              <div class="text-center">
-                <h5 class="card-title">${%select.row}</h5>
-              </div>
-            </div>
-            <div id="${id}-no-source">
-              <div class="text-center">
-                <fa:svg-icon name="ban" class="no-selection-banner"/>
-              </div>
-              <div class="text-center">
-                <h5 class="card-title">${%no.sourcecode}</h5>
-              </div>
-            </div>
-          </bs:card>
+          </l:card>
         </div>
       </j:when>
       <j:otherwise>
         <div class="col-12">
-          <bs:card title="${title}" symbol="${symbol}" class="flex-fill h-100">
-            <dt:table model="${it.getTableModel(id + '-table')}">
-              <j:if test="${showChangedToggle}">
-                <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}"/>
-              </j:if>
-            </dt:table>
-          </bs:card>
+          <l:card title="${title}">
+            <div class="flex-fill h-100">
+              <dt:table model="${it.getTableModel(id + '-table')}">
+                <j:if test="${showChangedToggle}">
+                  <f:toggleSwitch id="changed-${id + '-table'}" title="${%changed.files}"/>
+                </j:if>
+              </dt:table>
+            </div>
+          </l:card>
         </div>
 
       </j:otherwise>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/source/SourceViewModel/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/source/SourceViewModel/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5" xmlns:l="/lib/layout">
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
@@ -7,11 +7,11 @@
 
     <link rel="stylesheet" href="${resURL}/plugin/coverage/css/view-model.css"/>
 
-    <div class="row py-3 flex-nowrap">
+    <div class="row flex-nowrap">
 
       <div class="col">
-        <div id="file-table">
-          <bs:card title="${%Source code view}" fontAwesomeIcon="file-code" fontAwesomeStyle="regular" class="flex-fill">
+        <div id="file-table" class="flex-fill">
+          <l:card title="${%Source code view}">
             <j:choose>
               <j:when test="${it.sourceFileAvailable}">
                 <div style="overflow-x:scroll;">
@@ -33,13 +33,11 @@
               </j:otherwise>
             </j:choose>
 
-          </bs:card>
+          </l:card>
         </div>
       </div>
 
     </div>
-
-
 
   </bs:page>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel/index.jelly
@@ -1,9 +1,9 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5" xmlns:cov="/coverage" xmlns:c="/charts">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5" xmlns:cov="/coverage" xmlns:c="/charts" xmlns:l="/lib/layout">
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
-  <bs:page it="${it}" class="fluid-container d-flex flex-column">
+  <bs:page it="${it}">
 
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.data-tables-select"/>
@@ -57,16 +57,16 @@
 
       <div role="tabpanel" id="overview" class="tab-pane fade" aria-labelledby="overview-tab" >
         <j:if test="${hasCoverage}">
-          <div class="row py-3">
+          <div class="row">
             <div class="col-5">
-              <bs:card title="${%Total coverage overview}" fontAwesomeIcon="chart-bar">
+              <l:card title="${%Total coverage overview}">
                 <div id="coverage-overview" class="graph-cursor-pointer overview-chart h-100"/>
-              </bs:card>
+              </l:card>
             </div>
             <div class="col-7">
-              <bs:card title="${%Coverage trend}" fontAwesomeIcon="chart-line">
+              <l:card title="${%Coverage trend}">
                 <div id="coverage-trend" class="graph-cursor-pointer overview-chart h-100"/>
-              </bs:card>
+              </l:card>
             </div>
           </div>
         </j:if>
@@ -74,23 +74,23 @@
       <j:if test="${hasMetrics}">
         <div role="tabpanel" id="metrics" class="tab-pane fade" aria-labelledby="metrics-tab" >
           <div class="row">
-            <div class="col-12 py-3">
-              <bs:card title="${%Metrics trend}" fontAwesomeIcon="chart-line">
+            <div class="col-12">
+              <l:card title="${%Metrics trend}">
                 <div id="metrics-trend" class="graph-cursor-pointer overview-chart h-100"/>
-              </bs:card>
+              </l:card>
             </div>
           </div>
         </div>
       </j:if>
       <j:forEach var="metric" items="${it.treeMetrics}">
         <div role="tabpanel" id="${metric.toTagName()}" class="tab-pane fade" aria-labelledby="${metric.toTagName()}-tab">
-          <bs:card title="${formatter.getDisplayName(metric)}" fontAwesomeIcon="folder-tree" class="flex-fill" bodyClass="d-flex flex-column">
+          <l:card title="${formatter.getDisplayName(metric)}">
             <div id="project-${metric.toTagName()}" class="graph-cursor-pointer tree-chart"
                  data-item-name="project-${metric.toTagName()}"
                  data-item-order="${metric.getTendency()}"
                  data-item-coverage="${metric.coverage}"
             />
-          </bs:card>
+          </l:card>
         </div>
       </j:forEach>
 


### PR DESCRIPTION
Replace Bootstrap cards with Jenkins cards to make all views consistent with the Jenkins design library.

Followup to https://github.com/jenkinsci/warnings-ng-plugin/pull/2067.

<img width="1450" height="724" alt="Bildschirmfoto 2025-08-03 um 12 08 56" src="https://github.com/user-attachments/assets/0f8a83f8-4fb6-493e-b886-511462b46a3e" />
<img width="1457" height="773" alt="Bildschirmfoto 2025-08-03 um 12 09 07" src="https://github.com/user-attachments/assets/f8cf3933-f1c5-4a6b-a1e3-1de70c9a547f" />
<img width="1465" height="936" alt="Bildschirmfoto 2025-08-03 um 12 09 33" src="https://github.com/user-attachments/assets/cb9957f6-de1a-47b0-aa76-354e2960dec4" />
