### PR TITLE
[JENKINS-73975] Hide delta header if not applicable

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -464,7 +464,11 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      */
     @SuppressWarnings("unused") // Called by jelly view
     public boolean hasDelta(final Baseline baseline) {
-        return baseline == Baseline.PROJECT || baseline == Baseline.MODIFIED_LINES
+        if (differences.isEmpty()) {
+            return false;
+        }
+        return baseline == Baseline.PROJECT
+                || baseline == Baseline.MODIFIED_LINES
                 || baseline == Baseline.MODIFIED_FILES;
     }
 
@@ -594,7 +598,8 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      * @param metric
      *         the metric to check
      *
-     * @return a positive value if the trend is positive, a negative value if the trend is negative, or {@code 0} if there is no significant change in the trend
+     * @return a positive value if the trend is positive, a negative value if the trend is negative, or {@code 0} if
+     *         there is no significant change in the trend
      */
     @SuppressWarnings("unused") // Called by jelly view
     public double getTrend(final Baseline baseline, final Metric metric) {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
@@ -111,12 +111,16 @@ class CoverageBuildActionTest {
     void shouldReturnZeroForDeltaWithinBoundaries() {
         var action = createCoverageBuildActionWithDelta(createSingleton(Fraction.getFraction(9, 10_000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isZero();
+
+        assertThat(action.hasDelta(Baseline.PROJECT)).isTrue();
     }
 
     @Test
     void shouldReturnZeroWhenDeltaIsNotPresentForGivenMetric() {
         var action = createCoverageBuildActionWithDelta(List.of());
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isZero();
+
+        assertThat(action.hasDelta(Baseline.PROJECT)).isFalse();
     }
 
     private List<Difference> createSingleton(final Fraction fraction) {


### PR DESCRIPTION
When no differences are recorded, then the header of the summary should not show the delta in brackets.

See [JENKINS-73975](https://issues.jenkins.io/browse/JENKINS-73975) for details.
