### PR TITLE
Ignore UI tests during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,28 @@
     <tag>${scmTag}</tag>
   </scm>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  <profiles>
+    <profile>
+      <id>quick-build</id>
+      <modules>
+        <module>plugin</module>
+      </modules>
+    </profile>
+  </profiles>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
During a release, the quick-build profile is active. So no tests and analysis is started.

