### PR TITLE
[JENKINS-76020] Resolve missing architecture rules

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -147,6 +147,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -161,6 +162,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/archunit/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/archunit/PluginArchitectureTest.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-import edu.hm.hafner.util.ArchitectureRules;
+import edu.hm.hafner.archunit.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
 


### PR DESCRIPTION
Bump the version of plugin-util to 6.1165.v322e76215b_a_4. This version contains the missing class again.