### PR TITLE
Add **/jacocoTestReport.xml to the default JaCoCo pattern

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
@@ -225,7 +225,7 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
                 "**/*coverage*.out,**/*coverage*.txt,**/cover.out",
                 "symbol-footsteps-outline plugin-ionicons-api"),
         JACOCO(Messages._Parser_JaCoCo(), ParserType.COVERAGE,
-                "**/jacoco.xml",
+                "**/jacoco.xml,**/jacocoTestReport.xml",
                 "symbol-footsteps-outline plugin-ionicons-api"),
         JUNIT(Messages._Parser_Junit(), ParserType.TEST,
                 "**/TEST-*.xml",

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
@@ -603,9 +603,9 @@ class CoveragePluginITest extends AbstractCoverageITest {
         Run<?, ?> run = buildWithResult(job, Result.SUCCESS);
 
         assertThat(getConsoleLog(run))
-                .contains("Using default pattern '**/jacoco.xml' since user defined pattern is not set",
-                        "[-ERROR-] No files found for pattern '**/jacoco.xml'. Configuration error?")
-                .containsPattern("Searching for all files in '.*' that match the pattern '\\*\\*/jacoco.xml'")
+                .contains("Using default pattern '**/jacoco.xml,**/jacocoTestReport.xml' since user defined pattern is not set",
+                        "[-ERROR-] No files found for pattern '**/jacoco.xml,**/jacocoTestReport.xml'. Configuration error?")
+                .containsPattern("Searching for all files in '.*' that match the pattern '\\*\\*/jacoco.xml,\\*\\*/jacocoTestReport.xml'")
                 .doesNotContain("Expanding pattern");
     }
 
@@ -623,7 +623,7 @@ class CoveragePluginITest extends AbstractCoverageITest {
         Run<?, ?> run = buildWithResult(job, Result.SUCCESS);
 
         assertThat(getConsoleLog(run))
-                .contains("Using default pattern '**/jacoco.xml' since user defined pattern is not set",
+                .contains("Using default pattern '**/jacoco.xml,**/jacocoTestReport.xml' since user defined pattern is not set",
                         "-> found 1 file",
                         "MODULE: 100.00% (1/1)",
                         "PACKAGE: 100.00% (1/1)",
@@ -634,7 +634,7 @@ class CoveragePluginITest extends AbstractCoverageITest {
                         "LINE: 91.02% (294/323)",
                         "BRANCH: 93.97% (109/116)",
                         "COMPLEXITY: 160")
-                .containsPattern("Searching for all files in '.*' that match the pattern '\\*\\*/jacoco.xml'")
+                .containsPattern("Searching for all files in '.*' that match the pattern '\\*\\*/jacoco.xml,\\*\\*/jacocoTestReport.xml'")
                 .containsPattern("Successfully parsed file .*/jacoco.xml")
                 .doesNotContain("Expanding pattern");
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This adds the `**/jacocoTestReport.xml` to the default JaCoCo pattern for reports match.

`jacocoTestReport.xml` is the name given by default when running JaCoCo through Gradle.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Not tested yet.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
