### PR TITLE
[JENKINS-76084] Revert tight styling of column cells

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/column.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/column.jelly
@@ -8,7 +8,7 @@
   <j:choose>
     <j:when test="${coverageValue.isPresent()}">
 
-      <td class="jenkins-table__cell--tight">
+      <td style="padding-left: calc(var(--table-padding) * 0.4); padding-right: calc(var(--table-padding) * 0.4); text-align: right">
 
         <j:set var="displayColors" value="${it.getDisplayColors(job, coverageValue)}"/>
         <j:set var="backgroundColor" value="${displayColors.getFillColorAsRGBAHex(80)}"/>
@@ -31,7 +31,7 @@
       </td>
     </j:when>
     <j:otherwise>
-      <td class="jenkins-table__cell--tight">
+      <td style="padding-left: calc(var(--table-padding) * 0.4); padding-right: calc(var(--table-padding) * 0.4); text-align: right">
         ${coverageText}
       </td>
     </j:otherwise>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/columnHeader.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageMetricColumn/columnHeader.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <th class="jenkins-table__cell--tight" align="right">${it.columnName}</th>
+    <th style="padding-left: calc(var(--table-padding) * 0.4); padding-right: calc(var(--table-padding) * 0.4); text-align: right">${it.columnName}</th>
 </j:jelly>


### PR DESCRIPTION
The tight cell styling introduced in #464 does not work well when multiple columns are used.

Fixes https://issues.jenkins.io/browse/JENKINS-76084

