### PR TITLE
Render `&nbsp;` correctly in coverage table header

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/VectorCastSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/VectorCastSourcePrinter.java
@@ -220,7 +220,7 @@ public class VectorCastSourcePrinter extends CoverageSourcePrinter {
             trString = tr().withClass(UNDEFINED).with(
                 td().withClass("line").with(text("Line ")),
                 td().withClass("line").with(text("St/Br")),
-                td().withClass("line").with(text(NBSP))
+                td().withClass("line").with(rawHtml(NBSP))
             ).render();
         }
 


### PR DESCRIPTION
Fix: render &nbsp; correctly in coverage table header

### Description:
This PR corrects HTML escaping in the coverage report table header.
Previously, the non-breaking space (&nbsp;) was being added using

    td().withClass("line").with(text(NBSP))

which caused it to render literally as “&nbsp;” in browsers.

This change replaces it with:

    td().withClass("line").with(rawHtml(NBSP))

so the HTML entity is no longer double-escaped and displays correctly as a non-breaking space in the rendered report.

### Impact:
   Fixes display of column spacing in coverage report headers.
   No functional or behavioral impact on metrics or data.

### Testing done

Standard testing done with commit from GitHub action

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

**Label:** bug
