### PR TITLE
Restore serialization to use interfaces again

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
@@ -8,6 +8,7 @@ import edu.hm.hafner.coverage.FileNode;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.NavigableSet;
 import java.util.TreeSet;
 
 import io.jenkins.plugins.prism.Sanitizer;
@@ -36,8 +37,8 @@ class CoverageSourcePrinter implements Serializable {
 
     private final int[] missedPerLine;
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final TreeSet<Integer> modifiedLines;
+    @SuppressWarnings("serial")
+    private final NavigableSet<Integer> modifiedLines;
 
     CoverageSourcePrinter(final FileNode file) {
         path = file.getRelativePath();

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
@@ -123,8 +123,8 @@ public class SourceCodePainter {
         @Serial
         private static final long serialVersionUID = 3966282357309568323L;
 
-        @SuppressWarnings("PMD.LooseCoupling")
-        private final ArrayList<? extends CoverageSourcePrinter> paintedFiles;
+        @SuppressWarnings("serial")
+        private final List<? extends CoverageSourcePrinter> paintedFiles;
         private final String sourceCodeEncoding;
         private final String directory;
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -73,41 +73,41 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
     private final FilteredLog log;
 
     /** The aggregated values of the result for the root of the tree. */
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<? extends Value> projectValues;
+    @SuppressWarnings("serial")
+    private final List<? extends Value> projectValues;
 
     /** The delta of this build's coverages with respect to the reference build. */
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "Not used anymore")
     private transient NavigableMap<Metric, Difference> difference;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private /* almost final */ ArrayList<Difference> differences; // since 2.0.0
+    @SuppressWarnings("serial")
+    private /* almost final */ List<Difference> differences; // since 2.0.0
 
     /** The coverages filtered by modified lines of the associated change request. */
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<? extends Value> modifiedLinesCoverage;
+    @SuppressWarnings("serial")
+    private final List<? extends Value> modifiedLinesCoverage;
 
     /** The coverage delta of the associated change request with respect to the reference build. */
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "Not used anymore")
     private transient NavigableMap<Metric, Difference> modifiedLinesCoverageDifference;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private /* almost final */ ArrayList<Difference> modifiedLinesDifferences; // since 2.0.0
+    @SuppressWarnings("serial")
+    private /* almost final */ List<Difference> modifiedLinesDifferences; // since 2.0.0
 
     /** The coverage of the modified lines. */
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<? extends Value> modifiedFilesCoverage;
+    @SuppressWarnings("serial")
+    private final List<? extends Value> modifiedFilesCoverage;
 
     /** The coverage delta of the modified lines. */
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "Not used anymore")
     private transient NavigableMap<Metric, Difference> modifiedFilesCoverageDifference;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private /* almost final */ ArrayList<Difference> modifiedFilesDifferences; // since 2.0.0
+    @SuppressWarnings("serial")
+    private /* almost final */ List<Difference> modifiedFilesDifferences; // since 2.0.0
 
     /** The indirect coverage changes of the associated change request with respect to the reference build. */
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<? extends Value> indirectCoverageChanges;
+    @SuppressWarnings("serial")
+    private final List<? extends Value> indirectCoverageChanges;
 
     static {
         CoverageXmlStream.registerConverters(XSTREAM2);
@@ -235,8 +235,7 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
         }
     }
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private <T> ArrayList<T> copy(final List<? extends T> list) {
+    private <T> List<T> copy(final List<? extends T> list) {
         return new ArrayList<>(list); // do not use immutable collections to simplify serialization
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
@@ -57,10 +57,10 @@ public class CoverageStep extends Step implements Serializable {
     private static final long serialVersionUID = 34386077204781270L;
     private static final ValidationUtilities VALIDATION_UTILITIES = new ValidationUtilities();
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private ArrayList<CoverageTool> tools = new ArrayList<>();
-    @SuppressWarnings("PMD.LooseCoupling")
-    private ArrayList<CoverageQualityGate> qualityGates = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private List<CoverageTool> tools = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private List<CoverageQualityGate> qualityGates = new ArrayList<>();
     private String id = StringUtils.EMPTY;
     private String name = StringUtils.EMPTY;
     private boolean skipPublishingChecks = false;
@@ -72,8 +72,8 @@ public class CoverageStep extends Step implements Serializable {
     private boolean skipSymbolicLinks = false;
     private String scm = StringUtils.EMPTY;
     private String sourceCodeEncoding = StringUtils.EMPTY;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private HashSet<SourceCodeDirectory> sourceDirectories = new HashSet<>();
+    @SuppressWarnings("serial")
+    private Set<SourceCodeDirectory> sourceDirectories = new HashSet<>();
     private SourceCodeRetention sourceCodeRetention = SourceCodeRetention.LAST_BUILD;
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/PathResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/PathResolver.java
@@ -81,12 +81,12 @@ public class PathResolver {
         private static final long serialVersionUID = 3966282357309568323L;
         private static final PathUtil PATH_UTIL = new PathUtil();
 
-        @SuppressWarnings("PMD.LooseCoupling")
-        private final HashSet<String> relativePaths;
-        @SuppressWarnings("PMD.LooseCoupling")
-        private final HashSet<String> permittedSourceDirectories;
-        @SuppressWarnings("PMD.LooseCoupling")
-        private final HashSet<String> requestedSourceDirectories;
+        @SuppressWarnings("serial")
+        private final Set<String> relativePaths;
+        @SuppressWarnings("serial")
+        private final Set<String> permittedSourceDirectories;
+        @SuppressWarnings("serial")
+        private final Set<String> requestedSourceDirectories;
 
         /**
          * Creates a new instance of {@link AgentPathResolver}.


### PR DESCRIPTION
Changing the fields to serializable classes breaks the existing serializations.