### PR TITLE
Revert version of j2html to 1.4.0

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -121,6 +121,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
+      <version>6.0.0-1279.v4e95ca_f54783</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -133,6 +134,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>data-tables-api</artifactId>
+      <version>2.3.7-1556.vb_8e745408397</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -141,7 +143,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>7.1320.v684dd26fca_19</version>
+      <version>7.1330.v47b_46ee2047a_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -6,7 +6,6 @@ import edu.hm.hafner.coverage.Difference;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
-import edu.hm.hafner.echarts.JacksonFacade;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,6 +23,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import tools.jackson.databind.ObjectMapper;
 
 import org.kohsuke.stapler.StaplerProxy;
 import hudson.Functions;
@@ -697,11 +697,11 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
     }
 
     private String createCoverageModel(final String configuration) {
-        return new JacksonFacade().toJson(new TrendChartFactory().createChartModel(configuration, this));
+        return new ObjectMapper().writeValueAsString(new TrendChartFactory().createChartModel(configuration, this));
     }
 
     private String createMetricsModel(final String configuration) {
-        return new JacksonFacade().toJson(new TrendChartFactory().createMetricsModel(configuration, this));
+        return new ObjectMapper().writeValueAsString(new TrendChartFactory().createMetricsModel(configuration, this));
     }
 
     @NonNull

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/TrendChartFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/TrendChartFactory.java
@@ -1,19 +1,17 @@
 package io.jenkins.plugins.coverage.metrics.steps;
 
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
-import tools.jackson.core.JacksonException;
-
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
-import edu.hm.hafner.echarts.JacksonFacade;
 import edu.hm.hafner.echarts.line.LinesChartModel;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import io.jenkins.plugins.coverage.metrics.charts.CoverageTrendChart;
 import io.jenkins.plugins.coverage.metrics.charts.MetricsTrendChart;
@@ -27,7 +25,6 @@ import io.jenkins.plugins.echarts.GenericBuildActionIterator.BuildActionIterable
  * @author Ullrich Hafner
  */
 class TrendChartFactory {
-    private static final JacksonFacade JACKSON = new JacksonFacade();
     static final Set<Metric> DEFAULT_TREND_METRICS = Set.of(
             Metric.LINE, Metric.BRANCH,
             Metric.MUTATION, Metric.TEST_STRENGTH,
@@ -62,7 +59,22 @@ class TrendChartFactory {
     }
 
     private boolean useLines(final String configuration) {
-        return JACKSON.getBoolean(configuration, "useLines", false);
+        return getBoolean(configuration, "useLines", false);
+    }
+
+    private boolean getBoolean(final String json, final String property, final boolean defaultValue) {
+        try {
+            var node = new ObjectMapper().readValue(json, ObjectNode.class);
+            var typeNode = node.get(property);
+            if (typeNode != null) {
+                return typeNode.asBoolean(defaultValue);
+            }
+        }
+        catch (JacksonException exception) {
+            // ignore
+        }
+
+        return defaultValue;
     }
 
     Set<Metric> getVisibleMetrics(final String configuration) {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>12.3140.v667559b_d0470</version>
+    <version>12.3159.v1734d34dfb_fc</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Versions starting from 1.5.0 are not backward-compatible anymore.