### PR TITLE
Use English locale when rendering numbers in XML attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ then this style will be used automatically.
 
 Moreover, (since this project is about static code analysis :wink:) a configuration for the following static code
 analysis tools is defined in the POM (and the `etc` and `.idea` folders of the `codingstyle` module):
-- [Checkstyle](https://checkstyle.sourceforge.net/)
+- [Checkstyle](https://checkstyle.org/)
 - [PMD](https://pmd.github.io/)
 - [SpotBugs](https://spotbugs.github.io)
 - [Error Prone](https://errorprone.info)

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTableModel.java
@@ -293,7 +293,7 @@ class CoverageTableModel extends TableModel {
         }
 
         public int getTests() {
-            return  file.getTypedValue(Metric.TESTS, ZERO_TESTS).asInteger();
+            return file.getTypedValue(Metric.TESTS, ZERO_TESTS).asInteger();
         }
 
         public int getCyclomaticComplexity() {
@@ -324,16 +324,16 @@ class CoverageTableModel extends TableModel {
             if (coverage.isSet()) {
                 double percentage = coverage.asRounded();
                 DisplayColors colors = CoverageLevel.getDisplayColorsOfCoverageLevel(percentage, colorProvider);
+                var style = String.format(Locale.ENGLISH,
+                        "background-image: linear-gradient(90deg, %s %f%%, transparent %f%%);",
+                        colors.getFillColorAsRGBAHex(TABLE_COVERAGE_COLOR_ALPHA), percentage, percentage);
                 var cell = div()
                         .withClasses(COVERAGE_COLUMN_OUTER).with(
-                        div().withClasses(COVERAGE_COLUMN_INNER)
-                                .withStyle("background-image: linear-gradient(90deg, %s %f%%, transparent %f%%);".formatted(
-                                        colors.getFillColorAsRGBAHex(TABLE_COVERAGE_COLOR_ALPHA),
-                                        percentage, percentage))
-                                .attr("data-bs-toggle", "tooltip")
-                                .attr("data-bs-placement", "top")
-                                .withTitle(FORMATTER.formatAdditionalInformation(coverage))
-                                .withText(FORMATTER.formatPercentage(coverage, browserLocale)))
+                                div().withClasses(COVERAGE_COLUMN_INNER).withStyle(style)
+                                        .attr("data-bs-toggle", "tooltip")
+                                        .attr("data-bs-placement", "top")
+                                        .withTitle(FORMATTER.formatAdditionalInformation(coverage))
+                                        .withText(FORMATTER.formatPercentage(coverage, browserLocale)))
                         .render();
                 return new DetailedCell<>(cell, percentage);
             }
@@ -354,10 +354,10 @@ class CoverageTableModel extends TableModel {
             double percentage = delta.asRounded();
             DisplayColors colors = CoverageChangeTendency.getDisplayColorsForTendency(percentage, colorProvider);
             var cell = div().withClasses(COVERAGE_COLUMN_OUTER).with(
-                    div().withClasses(COVERAGE_COLUMN_INNER)
-                            .withStyle("background-color:%s;".formatted(colors.getFillColorAsRGBAHex(
-                                    TABLE_COVERAGE_COLOR_ALPHA)))
-                            .withText(FORMATTER.formatDelta(metric, delta, browserLocale)))
+                            div().withClasses(COVERAGE_COLUMN_INNER)
+                                    .withStyle("background-color:%s;".formatted(colors.getFillColorAsRGBAHex(
+                                            TABLE_COVERAGE_COLOR_ALPHA)))
+                                    .withText(FORMATTER.formatDelta(metric, delta, browserLocale)))
                     .render();
             return new DetailedCell<>(cell, percentage);
         }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModelTest.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.coverage.metrics.steps;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.Issue;
 
 import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.ModuleNode;
@@ -59,6 +61,17 @@ class CoverageViewModelTest extends AbstractCoverageTest {
         );
 
         assertThat(model.getTableRows(ABSOLUTE_COVERAGE_TABLE_ID)).startsWith("[{\"branchCoverage\":{\"display\":\"<div ");
+    }
+
+    @Test @DefaultLocale("fr") @Issue("https://github.com/jenkinsci/coverage-plugin/issues/733")
+    void shouldUseEnglishLocalWhenRenderingNumbers() {
+        var model = createModelFromCodingStyleReport();
+
+        assertThat(model.getTableModel(ABSOLUTE_COVERAGE_TABLE_ID).getRows()).anySatisfy(
+                row -> assertThat(row).isInstanceOfSatisfying(CoverageRow.class,
+                        coverageRow -> assertThat(coverageRow.getLineCoverage().getDisplay())
+                                .contains("linear-gradient(90deg, #FFCC0050 80.000000%, transparent 80.000000%"))
+        );
     }
 
     private static void ensureValidPercentages(final List<Double> percentages) {


### PR DESCRIPTION
When rendering HTML tags the English locale needs to be used so that numbers are correctly rendered with a decimal point.

Fixes https://github.com/jenkinsci/coverage-plugin/issues/733.