### PR TITLE
Delete temporary ZIP file on agent after transferring painted sources

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -130,11 +130,11 @@ public class SourceCodeFacade {
      */
     void copySourcesToBuildFolder(final Run<?, ?> build, final FilePath workspace, final FilteredLog log)
             throws InterruptedException {
+        var buildFolder = new FilePath(build.getRootDir()).child(COVERAGE_SOURCES_DIRECTORY);
+        FilePath buildZip = buildFolder.child(COVERAGE_SOURCES_ZIP);
         var workspaceZip = workspace.child(COVERAGE_SOURCES_ZIP);
-        FilePath buildZip = null;
+
         try {
-            var buildFolder = new FilePath(build.getRootDir()).child(COVERAGE_SOURCES_DIRECTORY);
-            buildZip = buildFolder.child(COVERAGE_SOURCES_ZIP);
             workspaceZip.copyTo(buildZip);
             log.logInfo("-> extracting...");
             buildZip.unzip(buildFolder);
@@ -144,8 +144,31 @@ public class SourceCodeFacade {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
         }
         finally {
-            tryDeleteFile(buildZip, log);
-            tryDeleteFile(workspaceZip, log);
+            delete(buildZip, log);
+            delete(workspaceZip, log);
+        }
+    }
+
+    /**
+     * Deletes a file without throwing an IOException if the delete fails.
+     *
+     * @param file
+     *         the file to delete
+     * @param log
+     *         the log
+     *
+     * @throws InterruptedException
+     *         if the user terminated the job
+     */
+    private void delete(final FilePath file, final FilteredLog log)
+            throws InterruptedException {
+        try {
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+        catch (IOException exception) {
+            log.logException(exception, "Can't delete temporary file: '%s'", file);
         }
     }
 
@@ -325,29 +348,5 @@ public class SourceCodeFacade {
             linesMapping.put(String.valueOf(highestLine + 1), true);
         }
         return linesMapping;
-    }
-
-    /**
-     * Deletes a file without throwing an IOException if the delete fails.
-     *
-     * @param file
-     *         the file to delete
-     * @param log
-     *         the log
-     *
-     * @throws InterruptedException
-     *         if the user terminated the job
-     */
-    private void tryDeleteFile(final FilePath file, final FilteredLog log)
-            throws InterruptedException {
-        try {
-            if (file == null || !file.exists()) {
-                return;
-            }
-            file.delete();
-        }
-        catch (IOException exception) {
-            log.logException(exception, "Can't delete file: '%s'", file);
-        }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -144,8 +144,8 @@ public class SourceCodeFacade {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
         }
         finally {
-            deleteQuietly(buildZip, "controller temporary zip", log);
-            deleteQuietly(workspaceZip, "agent workspace zip", log);
+            buildZip.delete();
+            workspaceZip.delete();
         }
     }
 
@@ -325,34 +325,5 @@ public class SourceCodeFacade {
             linesMapping.put(String.valueOf(highestLine + 1), true);
         }
         return linesMapping;
-    }
-
-    /**
-     * Deletes a file without throwing exceptions. If the file is null or the deletion fails,
-     * the error is logged using the provided description.
-     *
-     * @param file
-     *         the file to delete, or {@code null}
-     * @param description
-     *         a description of the file being deleted (for logging purposes)
-     * @param log
-     *         the log to record any deletion errors
-     *
-     * @throws InterruptedException
-     *         if the deletion is interrupted
-     */
-    private void deleteQuietly(final FilePath file, final String description, final FilteredLog log)
-            throws InterruptedException {
-        if (file == null) {
-            return;
-        }
-        try {
-            if (file.exists()) {
-                file.delete();
-            }
-        }
-        catch (IOException exception) {
-            log.logException(exception, "Can't delete %s: '%s'", description, file);
-        }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -144,8 +144,8 @@ public class SourceCodeFacade {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
         }
         finally {
-            buildZip.delete();
-            workspaceZip.delete();
+            deleteQuietly(buildZip, "controller temporary zip", log);
+            deleteQuietly(workspaceZip, "agent workspace zip", log);
         }
     }
 
@@ -325,5 +325,34 @@ public class SourceCodeFacade {
             linesMapping.put(String.valueOf(highestLine + 1), true);
         }
         return linesMapping;
+    }
+
+    /**
+     * Deletes a file without throwing exceptions. If the file is null or the deletion fails,
+     * the error is logged using the provided description.
+     *
+     * @param file
+     *         the file to delete, or {@code null}
+     * @param description
+     *         a description of the file being deleted (for logging purposes)
+     * @param log
+     *         the log to record any deletion errors
+     *
+     * @throws InterruptedException
+     *         if the deletion is interrupted
+     */
+    private void deleteQuietly(final FilePath file, final String description, final FilteredLog log)
+            throws InterruptedException {
+        if (file == null) {
+            return;
+        }
+        try {
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+        catch (IOException exception) {
+            log.logException(exception, "Can't delete %s: '%s'", description, file);
+        }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -144,8 +144,8 @@ public class SourceCodeFacade {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
         }
         finally {
-            deleteQuietly(buildZip, "controller temporary zip", log);
-            deleteQuietly(workspaceZip, "agent workspace zip", log);
+            deleteQuietly(buildZip, log);
+            deleteQuietly(workspaceZip, log);
         }
     }
 
@@ -328,31 +328,26 @@ public class SourceCodeFacade {
     }
 
     /**
-     * Deletes a file without throwing exceptions. If the file is null or the deletion fails,
-     * the error is logged using the provided description.
+     * Deletes a file without throwing an IOException if the delete fails.
      *
      * @param file
-     *         the file to delete, or {@code null}
-     * @param description
-     *         a description of the file being deleted (for logging purposes)
+     *         the file to delete
      * @param log
-     *         the log to record any deletion errors
+     *         the log
      *
      * @throws InterruptedException
-     *         if the deletion is interrupted
+     *         if the user terminated the job
      */
-    private void deleteQuietly(final FilePath file, final String description, final FilteredLog log)
+    private void deleteQuietly(final FilePath file, final FilteredLog log)
             throws InterruptedException {
-        if (file == null) {
-            return;
-        }
         try {
-            if (file.exists()) {
-                file.delete();
+            if (file == null || !file.exists()) {
+                return;
             }
+            file.delete();
         }
         catch (IOException exception) {
-            log.logException(exception, "Can't delete %s: '%s'", description, file);
+            log.logException(exception, "Can't delete file: '%s'", file);
         }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -144,8 +144,8 @@ public class SourceCodeFacade {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
         }
         finally {
-            deleteQuietly(buildZip, log);
-            deleteQuietly(workspaceZip, log);
+            tryDeleteFile(buildZip, log);
+            tryDeleteFile(workspaceZip, log);
         }
     }
 
@@ -338,7 +338,7 @@ public class SourceCodeFacade {
      * @throws InterruptedException
      *         if the user terminated the job
      */
-    private void deleteQuietly(final FilePath file, final FilteredLog log)
+    private void tryDeleteFile(final FilePath file, final FilteredLog log)
             throws InterruptedException {
         try {
             if (file == null || !file.exists()) {

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -130,17 +130,22 @@ public class SourceCodeFacade {
      */
     void copySourcesToBuildFolder(final Run<?, ?> build, final FilePath workspace, final FilteredLog log)
             throws InterruptedException {
+        var workspaceZip = workspace.child(COVERAGE_SOURCES_ZIP);
+        FilePath buildZip = null;
         try {
             var buildFolder = new FilePath(build.getRootDir()).child(COVERAGE_SOURCES_DIRECTORY);
-            var buildZip = buildFolder.child(COVERAGE_SOURCES_ZIP);
-            workspace.child(COVERAGE_SOURCES_ZIP).copyTo(buildZip);
+            buildZip = buildFolder.child(COVERAGE_SOURCES_ZIP);
+            workspaceZip.copyTo(buildZip);
             log.logInfo("-> extracting...");
             buildZip.unzip(buildFolder);
-            buildZip.delete();
             log.logInfo("-> done");
         }
         catch (IOException exception) {
             log.logException(exception, "Can't copy zipped sources from agent to controller");
+        }
+        finally {
+            deleteQuietly(buildZip, "controller temporary zip", log);
+            deleteQuietly(workspaceZip, "agent workspace zip", log);
         }
     }
 
@@ -320,5 +325,34 @@ public class SourceCodeFacade {
             linesMapping.put(String.valueOf(highestLine + 1), true);
         }
         return linesMapping;
+    }
+
+    /**
+     * Deletes a file without throwing exceptions. If the file is null or the deletion fails,
+     * the error is logged using the provided description.
+     *
+     * @param file
+     *         the file to delete, or {@code null}
+     * @param description
+     *         a description of the file being deleted (for logging purposes)
+     * @param log
+     *         the log to record any deletion errors
+     *
+     * @throws InterruptedException
+     *         if the deletion is interrupted
+     */
+    private void deleteQuietly(final FilePath file, final String description, final FilteredLog log)
+            throws InterruptedException {
+        if (file == null) {
+            return;
+        }
+        try {
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+        catch (IOException exception) {
+            log.logException(exception, "Can't delete %s: '%s'", description, file);
+        }
     }
 }


### PR DESCRIPTION
This change fixes a workspace cleanup gap in source-code retention handling for coverage reports.

When painted source files are generated, the plugin creates coverage-sources.zip in the agent workspace, copies it to the controller build folder, extracts it, and deletes the controller-side zip. The agent-side zip was not deleted, which leaves coverage-sources.zip in the workspace root after builds.

### Open Issue

This PR addresses [GitHub Issue #750: coverage-sources.zip is left behind in agent workspace after each build](https://github.com/jenkinsci/coverage-plugin/issues/750)

### Root Cause

The transfer flow cleaned up only the temporary zip in the controller build folder and did not clean up the corresponding zip file in the agent workspace.

### What Changed

- Updated copySourcesToBuildFolder(...) to track both:
  - the controller temporary zip
  - the agent workspace zip
- Added a finally-based cleanup path so deletion is attempted regardless of success/failure of copy or unzip.
- Added a small helper to safely delete FilePath entries with defensive null/existence checks and non-fatal logging on IO issues.
- Preserved interrupt behavior (InterruptedException is still propagated).

### Why I Think This Solution Is Safe

- No change to coverage parsing, metrics, or report rendering logic.
- No change to retention policy semantics.
- Only lifecycle cleanup of temporary transfer artifacts was adjusted.

### Behavior Before vs After

Before: controller temp zip deleted; agent workspace coverage-sources.zip could remain.

After: both controller temp zip and agent workspace coverage-sources.zip are cleaned up.

### Impact

- Prevents accumulation of coverage-sources.zip in agent workspaces.
- Reduces workspace clutter and potential disk growth over repeated builds.

### Testing Done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I did not run this code or write unit tests. I do not have a Java environment set up to compile this project. I am hoping one of the maintainers can pull this branch, write or run a basic test, and ensure that testing requirements for this project are met.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

### Disclaimer

This PR is provided in good faith as a starting point to resolve [GitHub Issue #750: coverage-sources.zip is left behind in agent workspace after each build](https://github.com/jenkinsci/coverage-plugin/issues/750). The submitter expects the maintainers to verify that this is the correct fix for this issue and that the changes included in this PR function according to the expectations of the project maintainers.