### PR TITLE
Delete temporary output folder after zipping painted sources

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
@@ -175,6 +175,8 @@ public class SourceCodePainter {
                 log.logInfo("-> zipping sources from folder '%s' as '%s'", outputFolder, zipFile);
 
                 deleteFolder(temporaryFolder.toFile(), log);
+                outputFolder.deleteRecursive();
+                log.logInfo("-> deleted temporary source folder '%s'", outputFolder);
             }
             catch (IOException exception) {
                 log.logException(exception,


### PR DESCRIPTION
This change fixes a workspace cleanup gap in source-code retention handling for coverage reports.

When painted source files are generated, the plugin creates a temporary directory in the agent workspace named after the recordCoverage id (for example: my-coverage-report), writes per-file zipped painted sources into that directory, then zips the directory into coverage-sources.zip for transfer to the controller. The transfer zip is cleaned up, but the temporary id-named directory was not deleted, so it remained in the agent workspace after each build.

### Open Issue

This PR addresses [GitHub Issue #752: coverage-sources.zip is left behind in agent workspace after each build](https://github.com/jenkinsci/coverage-plugin/issues/752)

### Root Cause

In AgentCoveragePainter.invoke(...), the code zips outputFolder into coverage-sources.zip, but cleanup only removed the JVM temp folder used during rendering. The outputFolder itself (workspace/id) was never deleted.

### What Changed

- Added cleanup of the agent workspace temporary output folder after zipping is complete.
- Kept existing behavior for creating per-file zipped painted sources and packaging them into coverage-sources.zip.
- Did not change coverage parsing, metrics calculations, source rendering content, or retention semantics.

### Why I Think This Solution Is Safe

- The id-named workspace folder is a transport/staging artifact used only before packaging.
- Deleting it after successful packaging does not affect the extracted artifacts stored in the build folder on the controller.
- The change is scoped to artifact lifecycle cleanup only.

### Behavior Before vs After

Before: workspace/id temporary folder remained after builds.

After: workspace/id temporary folder is deleted after packaging, so no temporary painted-source folder remains in the agent workspace root.

### Impact

- Prevents accumulation and visibility of temporary .zip artifacts in id-named workspace folders.
- Reduces workspace clutter and avoids unexpected untracked artifacts in environments that validate workspace cleanliness.

### Testing Done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I did not run this code or write unit tests. I do not have a Java environment set up to compile this project. I am hoping one of the maintainers can pull this branch, write or run a basic test, and ensure that testing requirements for this project are met.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

### Disclaimer

This PR is provided in good faith as a starting point to resolve GitHub Issue #752. The submitter expects maintainers to verify that this is the correct fix and that the changes behave according to project expectations.
