### PR TITLE
Log periodic progress during source code painting to eliminate silent 4-minute gap in console output

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -176,8 +177,18 @@ public class SourceCodePainter {
                 Path temporaryFolder = Files.createTempDirectory(directory);
 
                 try {
+                    int total = paintedFiles.size();
+                    int logInterval = Math.max(100, total / 10);
+                    var painted = new AtomicInteger(0);
                     int count = paintedFiles.parallelStream()
-                            .mapToInt(file -> paintSource(file, workspace, outputFolder, temporaryFolder, log))
+                            .mapToInt(file -> {
+                                int result = paintSource(file, workspace, outputFolder, temporaryFolder, log);
+                                int done = painted.incrementAndGet();
+                                if (done % logInterval == 0 || done == total) {
+                                    log.logInfo("--> painting progress: %d / %d source files", done, total);
+                                }
+                                return result;
+                            })
                             .sum();
 
                     if (count == paintedFiles.size()) {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainterTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.*;
 /**
  * Tests the class {@link SourceCodePainter}.
  * Verifies that source painting handles files with extended ASCII characters,
+ * progress logging during multi-file painting (JENKINS-76183),
  * the printer factory selection fix (JENKINS-75871), and that painting never
  * deletes a pre-existing workspace directory that shares the coverage ID name (#771).
  *
@@ -65,6 +67,67 @@ class SourceCodePainterTest {
 
         var renderedText = new String(paintedBytes, StandardCharsets.UTF_8).replace("\u00A0", " ");
         assertThat(renderedText).contains("Copyright 2026, Café Corporation");
+    }
+
+    /**
+     * Regression test for JENKINS-76183: source painting must emit periodic progress log messages
+     * so the console log is not silent for several minutes when processing many files.
+     */
+    @Test
+    @Issue("JENKINS-76183")
+    void shouldLogProgressWhilePaintingManySourceFiles() throws IOException, InterruptedException {
+        int fileCount = 250;
+        Path workspace = Files.createTempDirectory("source-painter-jenkins-76183");
+
+        List<CoverageSourcePrinter> printers = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            String name = "File" + i + ".java";
+            Files.writeString(workspace.resolve(name), "class File" + i + " {}");
+            printers.add(new CoverageSourcePrinter(new FileNode("", name)));
+        }
+
+        var painter = new SourceCodePainter.AgentCoveragePainter(
+                printers,
+                StandardCharsets.UTF_8.name(),
+                "coverage");
+
+        FilteredLog log = painter.invoke(workspace.toFile(), null);
+
+        assertThat(log.getErrorMessages()).isEmpty();
+        assertThat(log.getInfoMessages()).contains("-> finished painting successfully");
+
+        long progressMessages = log.getInfoMessages().stream()
+                .filter(msg -> msg.contains("--> painting progress:"))
+                .count();
+        assertThat(progressMessages)
+                .as("Expected at least one progress log message for %d files", fileCount)
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    /**
+     * Regression test for JENKINS-76183: even a single-file paint run should emit
+     * a progress message at completion (100%).
+     */
+    @Test
+    @Issue("JENKINS-76183")
+    void shouldLogProgressForSingleFile() throws IOException, InterruptedException {
+        Path workspace = Files.createTempDirectory("source-painter-jenkins-76183-single");
+        Files.writeString(workspace.resolve("Solo.java"), "class Solo {}");
+
+        var painter = new SourceCodePainter.AgentCoveragePainter(
+                List.of(new CoverageSourcePrinter(new FileNode("", "Solo.java"))),
+                StandardCharsets.UTF_8.name(),
+                "coverage");
+
+        FilteredLog log = painter.invoke(workspace.toFile(), null);
+
+        assertThat(log.getErrorMessages()).isEmpty();
+        long progressMessages = log.getInfoMessages().stream()
+                .filter(msg -> msg.contains("--> painting progress:"))
+                .count();
+        assertThat(progressMessages)
+                .as("Expected a final progress log message even for a single file")
+                .isGreaterThanOrEqualTo(1);
     }
 
     /**


### PR DESCRIPTION
Log periodic progress during source code painting to eliminate silent 4-minute gap in console output

Fixes #652 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
