### PR TITLE
Fix empty modified-lines REST API by making exported beans public

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileWithModifiedLines.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileWithModifiedLines.java
@@ -11,7 +11,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * described by its fully qualified name.
  */
 @ExportedBean
-class FileWithModifiedLines {
+public class FileWithModifiedLines {
     private final String fullyQualifiedFileName;
     private final SortedSet<ModifiedLinesBlock> modifiedLinesBlocks;
 
@@ -22,12 +22,12 @@ class FileWithModifiedLines {
     }
 
     @Exported(inline = true)
-    String getFullyQualifiedFileName() {
+    public String getFullyQualifiedFileName() {
         return fullyQualifiedFileName;
     }
 
     @Exported(inline = true)
-    SortedSet<ModifiedLinesBlock> getModifiedLinesBlocks() {
+    public SortedSet<ModifiedLinesBlock> getModifiedLinesBlocks() {
         return modifiedLinesBlocks;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/LineCoverageType.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/LineCoverageType.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.coverage.metrics.restapi;
 /**
  * Defines the type of line coverage.
  */
-enum LineCoverageType {
+public enum LineCoverageType {
     COVERED,
     MISSED,
     PARTIALLY_COVERED

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesBlock.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesBlock.java
@@ -12,7 +12,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * lines and comments are also included in blocks.
  */
 @ExportedBean
-class ModifiedLinesBlock implements Comparable<ModifiedLinesBlock> {
+public class ModifiedLinesBlock implements Comparable<ModifiedLinesBlock> {
     private final int startLine;
     private final int endLine;
     private final LineCoverageType type;
@@ -24,17 +24,17 @@ class ModifiedLinesBlock implements Comparable<ModifiedLinesBlock> {
     }
 
     @Exported
-    int getStartLine() {
+    public int getStartLine() {
         return startLine;
     }
 
     @Exported
-    int getEndLine() {
+    public int getEndLine() {
         return endLine;
     }
 
     @Exported
-    LineCoverageType getType() {
+    public LineCoverageType getType() {
         return type;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesCoverageApi.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesCoverageApi.java
@@ -17,7 +17,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * Remote API to list the details of modified line coverage results.
  */
 @ExportedBean
-class ModifiedLinesCoverageApi {
+public class ModifiedLinesCoverageApi {
     private final List<FileWithModifiedLines> filesWithModifiedLines;
 
     ModifiedLinesCoverageApi(final Node node) {
@@ -25,7 +25,7 @@ class ModifiedLinesCoverageApi {
     }
 
     @Exported(inline = true, name = "files")
-    List<FileWithModifiedLines> getFilesWithModifiedLines() {
+    public List<FileWithModifiedLines> getFilesWithModifiedLines() {
         return filesWithModifiedLines;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesCoverageApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/ModifiedLinesCoverageApiTest.java
@@ -6,11 +6,19 @@ import edu.hm.hafner.coverage.FileNode;
 import edu.hm.hafner.coverage.PackageNode;
 import edu.hm.hafner.util.LineRange;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.kohsuke.stapler.export.ExportConfig;
+import org.kohsuke.stapler.export.Flavor;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.ModelBuilder;
+
 import io.jenkins.plugins.coverage.metrics.AbstractModifiedFilesCoverageTest;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -35,6 +43,34 @@ class ModifiedLinesCoverageApiTest extends AbstractModifiedFilesCoverageTest {
         var expectedFileWithChangedLines = new FileWithModifiedLines("test/example/Test1.java", expectedLineBlocks);
 
         assertThat(filesWithChangedLines).containsExactly(expectedFileWithChangedLines);
+    }
+
+    /**
+     * Verifies that the exported bean is serialized by Stapler into a non-empty {@code files} array. This exercises the
+     * remote-API serialization layer (rather than the getter directly), which is where the exported {@code files}
+     * property would silently disappear if the bean or its accessors were not {@code public}: newer Stapler releases
+     * only export {@code public} members.
+     */
+    @Test
+    void shouldExportModifiedLinesAsJson() throws IOException {
+        var node = createCoverageTree();
+        var api = new ModifiedLinesCoverageApi(node);
+
+        var json = exportToJson(api);
+
+        assertThatJson(json).node("files").isArray().isNotEmpty();
+        assertThatJson(json).node("files[0].fullyQualifiedFileName").isEqualTo("test/example/Test1.java");
+        assertThatJson(json).node("files[0].modifiedLinesBlocks").isArray().isNotEmpty();
+        assertThatJson(json).node("files[0].modifiedLinesBlocks[0].startLine").isNumber();
+        assertThatJson(json).node("files[0].modifiedLinesBlocks[0].type").isString();
+    }
+
+    private String exportToJson(final ModifiedLinesCoverageApi api) throws IOException {
+        Model<ModifiedLinesCoverageApi> model = new ModelBuilder().get(ModifiedLinesCoverageApi.class);
+        try (var writer = new StringWriter()) {
+            model.writeTo(api, Flavor.JSON.createDataWriter(api, writer, new ExportConfig()));
+            return writer.toString();
+        }
     }
 
     @Test


### PR DESCRIPTION
The modified-lines coverage REST API (`.../coverage/modified/api/json`) returns a response
  with no `files` array on recent Jenkins cores, even though the coverage data is computed
  and stored correctly:

  ```json
  {"_class":"io.jenkins.plugins.coverage.metrics.restapi.ModifiedLinesCoverageApi"}
  ```

  **Root cause:** the classes backing this endpoint — `ModifiedLinesCoverageApi`,
  `FileWithModifiedLines`, `ModifiedLinesBlock`, and the `LineCoverageType` enum — and their
  `@Exported` getters are package-private. Recent Stapler releases only export `@Exported`
  members that are `public`, so `ModelBuilder` finds zero exported properties and the
  `files` property is silently dropped. Older Stapler reflected non-public members, which is
  why this regressed on a Jenkins core upgrade without any change to the plugin:

  | Jenkins core | Bundled Stapler | `files` in response |
  | --- | --- | --- |
  | 2.511 | `1983.v93c53e94b_c04` | present ✅ |
  | 2.555.3 | `2076.v1b_ac12445eb_e` | missing ❌ |

  The visibility was reduced in `cc8cdbd7` ("visibility changes in restapi package"); the
  defect stayed latent until Stapler's behavior tightened.

  **Fix:** make the four types and their `@Exported` accessors `public`.

  Fixes #785

  ### Testing done

  Added `ModifiedLinesCoverageApiTest#shouldExportModifiedLinesAsJson`, which serializes the
  bean through the same Stapler export path the endpoint uses (`ModelBuilder` +
  `Flavor.JSON`) and asserts a non-empty `files` array. Verified it **fails** on the
  package-private code and **passes** with the visibility fix:

  - Unpatched (package-private): `Different value found in node "files", expected: <array>
  but was: <missing>`
  - Patched (public): all 4 tests in the class pass

  The existing integration test that exercises this endpoint
  (`GitForensicsITest#verifyModifiedLinesCoverageApi`) is currently `@Disabled`, so this
  path had no active coverage — which is why the regression wasn't caught.

  Also manually reproduced end-to-end: on Jenkins 2.555.3 with coverage
  `3.3278.va_04d3e352354`, a build whose stored coverage data contains modified lines
  (confirmed via `filterByModifiedLines().getAllFileNodes()`) returned an empty response
  from `/coverage/modified/api/json`; after installing a locally built plugin with this fix,
  the same build returned the fully populated `files` array.

  ### Submitter checklist
  - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and
  not your main branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira
  - [ ] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is
  fixed
