### PR TITLE
Use per-id transfer archive for painted sources (#790)

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -38,12 +38,25 @@ import hudson.model.Run;
 public class SourceCodeFacade {
     /** Toplevel directory in the build folder of the controller that contains the zipped source files. */
     static final String COVERAGE_SOURCES_DIRECTORY = "coverage-sources";
-    static final String COVERAGE_SOURCES_ZIP = "coverage-sources.zip";
     static final int MAX_FILENAME_LENGTH = 245; // Windows has limitations on long file names
     static final String ZIP_FILE_EXTENSION = ".zip";
 
     static String sanitizeFilename(final String inputName) {
         return StringUtils.right(inputName.replaceAll("[^a-zA-Z0-9-_.]", "_"), MAX_FILENAME_LENGTH);
+    }
+
+    /**
+     * Returns the name of the transfer archive that holds the painted sources for a single coverage result. The name
+     * is unique per coverage ID so that concurrent {@code recordCoverage} steps of the same build (which all share the
+     * same build folder on the controller) do not overwrite or delete each other's archive.
+     *
+     * @param id
+     *         the ID of the coverage results
+     *
+     * @return the ID-specific name of the transfer archive
+     */
+    static String getCoverageSourcesZip(final String id) {
+        return COVERAGE_SOURCES_DIRECTORY + "-" + sanitizeFilename(id) + ZIP_FILE_EXTENSION;
     }
 
     /**
@@ -122,17 +135,21 @@ public class SourceCodeFacade {
      *         the build with the coverage result
      * @param workspace
      *         the workspace on the agent that created the ZIP file
+     * @param id
+     *         the ID of the coverage results, used to select the ID-specific transfer archive
      * @param log
      *         the log
      *
      * @throws InterruptedException
      *         in case the user terminated the job
      */
-    void copySourcesToBuildFolder(final Run<?, ?> build, final FilePath workspace, final FilteredLog log)
+    void copySourcesToBuildFolder(final Run<?, ?> build, final FilePath workspace, final String id,
+            final FilteredLog log)
             throws InterruptedException {
+        var zipName = getCoverageSourcesZip(id);
         var buildFolder = new FilePath(build.getRootDir()).child(COVERAGE_SOURCES_DIRECTORY);
-        FilePath buildZip = buildFolder.child(COVERAGE_SOURCES_ZIP);
-        var workspaceZip = workspace.child(COVERAGE_SOURCES_ZIP);
+        FilePath buildZip = buildFolder.child(zipName);
+        var workspaceZip = workspace.child(zipName);
 
         try {
             workspaceZip.copyTo(buildZip);

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
@@ -90,7 +90,7 @@ public class SourceCodePainter {
             paintFilesOnAgent(paintedFiles, sourceCodeEncoding, log);
             log.logInfo("Copying painted sources from agent to build folder");
 
-            sourceCodeFacade.copySourcesToBuildFolder(build, workspace, log);
+            sourceCodeFacade.copySourcesToBuildFolder(build, workspace, id, log);
         }
         sourceCodeRetention.cleanup(build, sourceCodeFacade.getCoverageSourcesDirectory(), log);
     }
@@ -188,7 +188,7 @@ public class SourceCodePainter {
                                 count, paintedFiles.size() - count);
                     }
 
-                    var zipFile = workspace.child(SourceCodeFacade.COVERAGE_SOURCES_ZIP);
+                    var zipFile = workspace.child(SourceCodeFacade.getCoverageSourcesZip(directory));
                     outputFolder.zip(zipFile);
                     log.logInfo("-> zipping sources from folder '%s' as '%s'", outputFolder, zipFile);
                 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacadeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacadeTest.java
@@ -50,6 +50,16 @@ class SourceCodeFacadeTest extends ResourceTest {
     }
 
     @Test
+    void shouldUseIdSpecificTransferArchiveName() {
+        assertThat(SourceCodeFacade.getCoverageSourcesZip("jacoco-unit"))
+                .isEqualTo("coverage-sources-jacoco-unit.zip");
+        assertThat(SourceCodeFacade.getCoverageSourcesZip("jacoco-ui"))
+                .isNotEqualTo(SourceCodeFacade.getCoverageSourcesZip("jacoco-unit"));
+        assertThat(SourceCodeFacade.getCoverageSourcesZip("weird/id name"))
+                .isEqualTo("coverage-sources-weird_id_name.zip");
+    }
+
+    @Test
     void shouldCalculateSourcecodeForModifiedLinesCoverage() throws IOException {
         var sourceCodeFacade = createSourceCodeFacade();
         var originalHtml = readHtml(WHOLE_SOURCE_CODE);

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainterTest.java
@@ -58,7 +58,7 @@ class SourceCodePainterTest {
         assertThat(log.getErrorMessages()).isEmpty();
         assertThat(log.getInfoMessages()).contains("-> finished painting successfully");
 
-        Path outerZipPath = workspace.resolve(SourceCodeFacade.COVERAGE_SOURCES_ZIP);
+        Path outerZipPath = workspace.resolve(SourceCodeFacade.getCoverageSourcesZip("coverage"));
         assertThat(outerZipPath).exists();
 
         byte[] paintedBytes = readPaintedBytesFromNestedZip(outerZipPath);


### PR DESCRIPTION
Fixes #790

Painted source files were transferred from the agent to the controller through a hardcoded archive name (`coverage-sources.zip`) under the per-build directory `build.getRootDir()/coverage-sources/`. Because that directory is shared by every `recordCoverage` step in the same build, concurrent steps (even on different agents) raced on the single archive:

- one step could overwrite it mid-unzip → `java.io.EOFException: Unexpected end of ZLIB input stream`;
- one step's `finally`-block delete removed it before another step's `unzip` → `java.io.FileNotFoundException: .../coverage-sources/coverage-sources.zip (No such file or directory)`.

The exception is caught and only logged, so the build stays green while the affected report ends up with a partially-extracted or empty `coverage-sources/<id>/` directory, and its files render as plain text (no source link) in the "Files" tab. A report that happens to run alone (e.g. an aggregate stage starting after the parallel ones finish) is unaffected.

Note the inconsistency that caused this: the painted-files temp *folder* is already randomized per run (`workspace.createTempDir("coverage-sources-", "")`), but the transfer *zip* used a fixed name on both the agent and controller side.

This change gives the transfer archive a per-id name (`coverage-sources-<sanitized-id>.zip`) on both the agent and controller sides, mirroring the already-per-`id` painted-sources directory. Concurrent `recordCoverage` steps no longer share a file, so they no longer collide regardless of parallelism or node placement.

### Testing done

- Added `SourceCodeFacadeTest.shouldUseIdSpecificTransferArchiveName`, which executes the new `getCoverageSourcesZip(String)` and asserts that (a) the name is the expected `coverage-sources-<id>.zip`, (b) two different ids produce different names (the property that prevents the collision), and (c) the id is sanitized.
- Updated `SourceCodePainterTest.shouldPaintSourceFilesWithExtendedAsciiCharacters` to assert against the new per-id archive name; the existing painter tests continue to exercise the changed agent-side zip creation path.
- Ran `SourceCodeFacadeTest` (4 tests) and `SourceCodePainterTest` (9 tests) locally — all pass.
- Manually verified against real build logs that exhibited the bug: two concurrent `recordCoverage` stages (unit + instrumented) failed with the `EOFException` / `FileNotFoundException` above, while a third (aggregate) that ran alone succeeded. The fix removes the shared file that those stages contended on.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
