### PR TITLE
Avoid bundling jackson jars

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -33,6 +33,8 @@
 
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+    <hpi.bundledArtifacts>coverage-model</hpi.bundledArtifacts>
 
     <!-- Library Dependencies Versions -->
     <coverage-model.version>0.71.1</coverage-model.version>
@@ -80,6 +82,18 @@
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
`coverage-model` pulls `jackson-annotations`, `jackson-core`, and `jackson-databind` as direct compile-scope deps, causing hpi to include it even when everything is already bundled by `jackson3-api` (an transitive `jackson-annotations2-api`)

### Testing done

```sh
mvn clean verify
unzip -l plugin/target/coverage.hpi | grep "WEB-INF/lib"
        0  2026-07-30 18:20   WEB-INF/lib/
   281014  2026-07-30 18:20   WEB-INF/lib/coverage.jar
   171109  2026-06-19 10:23   WEB-INF/lib/coverage-model-0.71.1.jar

```

Also `hpi:run` with a Pipeline job using `plugin/src/test/resources/io/jenkins/plugins/coverage/metrics/steps/jacoco.xml`.
<details>
<summary>it rendered correctly</summary>

<img width="1621" height="873" alt="Screenshot from 2026-07-30 16-50-04" src="https://github.com/user-attachments/assets/c86e651b-b485-4306-960e-0cf00c8bf769" />

</details>





### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed