### PR TITLE
Modernize the layout of the coverage source code view

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
@@ -53,7 +53,6 @@ class CoverageSourcePrinter implements Serializable {
         var isPainted = isPainted(line);
         return tr()
                 .withClasses(isPainted ? getColorClass(line) : UNDEFINED, getModifiedClass(line))
-                .condAttr(isPainted, "data-html-tooltip", isPainted ? getTooltip(line) : StringUtils.EMPTY)
                 .with(
                         td().withClass("line")
                                 .with(a().withName(String.valueOf(line)).withText(String.valueOf(line))),

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinter.java
@@ -102,6 +102,33 @@ final class MutationSourcePrinter extends CoverageSourcePrinter {
         return tr().withClass("mutation").render();
     }
 
+    /**
+     * Renders a source line with the mutation detail tooltip placed on the {@code td.hits} cell only.
+     *
+     * @param line
+     *         the 1-based line number
+     * @param sourceCode
+     *         the raw source code text for this line
+     *
+     * @return the rendered HTML {@code <tr>} element
+     */
+    @Override
+    String renderLine(final int line, final String sourceCode) {
+        var isPainted = isPainted(line);
+        return tr()
+                .withClasses(isPainted ? getColorClass(line) : UNDEFINED, getModifiedClass(line))
+                .with(
+                        td().withClass("line")
+                                .with(a().withName(String.valueOf(line)).withText(String.valueOf(line))),
+                        td().withClass("hits")
+                                .condAttr(isPainted, "data-html-tooltip",
+                                        isPainted ? getTooltip(line) : StringUtils.EMPTY)
+                                .with(isPainted ? text(getSummaryColumn(line)) : text(StringUtils.EMPTY)),
+                        td().withClass("code")
+                                .with(rawHtml(SANITIZER.render(cleanupCode(sourceCode)))))
+                .render();
+    }
+
     @Override
     String getColorClass(final int line) {
         if (getCovered(line) == 0) {

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinter.java
@@ -92,6 +92,16 @@ final class MutationSourcePrinter extends CoverageSourcePrinter {
         return getCounter(line, killedPerLine);
     }
 
+    /**
+     * Returns a hidden sentinel row that marks this table as a mutation coverage view.
+     *
+     * @return HTML string for the sentinel mutation row
+     */
+    @Override
+    String getColumnHeader() {
+        return tr().withClass("mutation").render();
+    }
+
     @Override
     String getColorClass(final int line) {
         if (getCovered(line) == 0) {

--- a/plugin/src/main/webapp/css/view-model.css
+++ b/plugin/src/main/webapp/css/view-model.css
@@ -133,33 +133,377 @@ table.source th {
     text-align: left;
 }
 
-table.source tr.coverFull {
-    background-color: var(--green);
-    color: var(--white);
-    font-weight: bold;
+/* --- Reset: all rows use the default background and text color --- */
+/* This overrides the old solid green/red/orange backgrounds */
+table.source tr {
+    position: relative;
+    background-color: var(--background-color) !important;
+    color: var(--text-color) !important;
+    font-weight: normal !important;
 }
 
-table.source tr.coverPart {
-    background-color: var(--orange);
-    color: var(--text-color);
-    font-weight: bold;
+table.source tr td {
+    font-weight: normal !important;
 }
 
-table.source tr.coverPart td.hits, table.source tr.coverNone td.hits {
-    font-weight: bold;
+/*
+ * "New Code" label appears above the FIRST row of a modified block.
+ * It is always visible (not hover-dependent) so users immediately know
+ * which lines are new/changed since the reference build.
+ */
+table.source tr:not(.modified) + tr.modified:after {
+    content: "New Code";
+    display: flex;
+    position: absolute;
+    right: 5px;
+    top: -23px;
+    background-color: rgba(159, 169, 237, 0.15);
+    color: rgb(93, 108, 208);
+    padding: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    height: 23px;
+    align-items: center;
+    font-family: monospace;
+    z-index: 2;
 }
 
-table.source tr.coverNone {
-    background-color: var(--red);
-    color: var(--white);
-    font-weight: bold;
+/*
+ * Blue overlay on every modified line's code cell.
+ * position:absolute fills the entire code cell without affecting layout.
+ */
+table.source tr.modified td.code:before {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(159, 169, 237, 0.15) !important;
 }
 
-table.source tr.noCover {
-    background-color: var(--background-color);
-    color: var(--text-color);
+/*
+ * "Uncovered code" label appears above the FIRST row of an uncovered block when any row in that block is hovered.
+ * Uses :has() to detect hover anywhere in the block and propagate upward.
+ */
+table.source tr:has(~ tr.coverNone:hover) ~ tr:not(.coverNone) + tr.coverNone:after {
+    content: "Uncovered code";
+    display: flex;
+    position: absolute;
+    right: 5px;
+    top: -23px;
+    background: rgba(240, 68, 56, 0.15);
+    color: rgb(217, 45, 32);
+    padding: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    height: 23px;
+    align-items: center;
+    font-family: monospace;
+    z-index: 2;
 }
 
+/* Highlight subsequent uncovered lines after the hovered uncovered line. */
+table.source tr.coverNone:hover ~ tr.coverNone td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(240, 68, 56, 0.15) !important;
+}
+
+/* Highlight preceding uncovered lines before the hovered uncovered line. */
+table.source tr.coverNone:has(~ tr.coverNone:hover) td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(240, 68, 56, 0.15) !important;
+}
+
+/* Highlight the hovered uncovered line itself. */
+table.source tr.coverNone:hover td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(240, 68, 56, 0.15) !important;
+}
+
+/* Don't highlight uncovered lines before the currently hovered uncovered block. */
+table.source tr.coverNone:has(~ tr.noCover ~ tr.coverNone:hover) td.code:after {
+    display: none !important;
+}
+
+/* Don't label uncovered lines before the currently hovered uncovered block. */
+table.source tr.coverNone:has(~ tr.noCover ~ tr.coverNone:hover):after {
+    display: none !important;
+}
+
+/* Don't highlight uncovered lines after the currently hovered uncovered block. */
+table.source tr.coverNone:hover ~ tr.noCover ~ tr.coverNone td.code:after {
+    display: none !important;
+}
+
+/* Don't label uncovered lines after the currently hovered uncovered block. */
+table.source tr.coverNone:hover ~ tr.noCover ~ tr.coverNone:after {
+    display: none !important;
+}
+
+/*
+ * "Covered code" label appears above the FIRST row of a covered block when any row in that block is hovered.
+ */
+table.source tr:has(~ tr.coverFull:hover) ~ tr:not(.coverFull) + tr.coverFull:after {
+    content: "Covered code";
+    display: flex;
+    position: absolute;
+    right: 5px;
+    top: -23px;
+    background: rgba(18, 183, 106, 0.15);
+    color: rgb(118, 175, 141);
+    padding: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    height: 23px;
+    align-items: center;
+    font-family: monospace;
+    z-index: 2;
+}
+
+/* Highlight subsequent covered lines after the hovered covered line. */
+table.source tr.coverFull:hover ~ tr.coverFull td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(18, 183, 106, 0.15) !important;
+}
+
+/* Highlight preceding covered lines before the hovered covered line. */
+table.source tr.coverFull:has(~ tr.coverFull:hover) td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(18, 183, 106, 0.15) !important;
+}
+
+/* Highlight the hovered covered line itself. */
+table.source tr.coverFull:hover td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(18, 183, 106, 0.15) !important;
+}
+
+/* Don't highlight covered lines before the currently hovered covered block. */
+table.source tr.coverFull:has(~ tr.noCover ~ tr.coverFull:hover) td.code:after {
+    display: none !important;
+}
+
+/* Don't label covered lines before the currently hovered covered block. */
+table.source tr.coverFull:has(~ tr.noCover ~ tr.coverFull:hover):after {
+    display: none !important;
+}
+
+/* Don't highlight covered lines after the currently hovered covered block. */
+table.source tr.coverFull:hover ~ tr.noCover ~ tr.coverFull td.code:after {
+    display: none !important;
+}
+
+/* Don't label covered lines after the currently hovered covered block. */
+table.source tr.coverFull:hover ~ tr.noCover ~ tr.coverFull:after {
+    display: none !important;
+}
+
+/*
+ * "Partially covered code" label appears above the FIRST row of a 
+ * partially-covered block when any row in that block is hovered.
+ */
+table.source tr:has(~ tr.coverPart:hover) ~ tr:not(.coverPart) + tr.coverPart:after {
+    content: "Partially covered code";
+    display: flex;
+    position: absolute;
+    right: 5px;
+    top: -23px;
+    background-color: rgba(255, 165, 0, 0.15);
+    color: rgb(255, 165, 0);
+    padding: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    height: 23px;
+    align-items: center;
+    font-family: monospace;
+    z-index: 2;
+}
+
+/* Highlight subsequent partially covered lines after the hovered line. */
+table.source tr.coverPart:hover ~ tr.coverPart td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(255, 165, 0, 0.15) !important;
+}
+
+/* Highlight preceding partially covered lines before the hovered line. */
+table.source tr.coverPart:has(~ tr.coverPart:hover) td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(255, 165, 0, 0.15) !important;
+}
+
+/* Highlight the hovered partially covered line itself. */
+table.source tr.coverPart:hover td.code:after {
+    content: "";
+    position: absolute;
+    display: flex;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    background: rgba(255, 165, 0, 0.15) !important;
+}
+
+/* Don't highlight partially covered lines before the currently hovered block. */
+table.source tr.coverPart:has(~ tr.noCover ~ tr.coverPart:hover) td.code:after {
+    display: none !important;
+}
+
+/* Don't label partially covered lines before the currently hovered block. */
+table.source tr.coverPart:has(~ tr.noCover ~ tr.coverPart:hover):after {
+    display: none !important;
+}
+
+/* Don't highlight partially covered lines after the currently hovered block. */
+table.source tr.coverPart:hover ~ tr.noCover ~ tr.coverPart td.code:after {
+    display: none !important;
+}
+
+/* Don't label partially covered lines after the currently hovered block. */
+table.source tr.coverPart:hover ~ tr.noCover ~ tr.coverPart:after {
+    display: none !important;
+}
+
+/* --- General row hover: light blue-grey background --- */
+table.source tr:hover td.line,
+table.source tr:hover td.hits,
+table.source tr:hover td.code {
+    background: rgb(239, 242, 249);
+}
+
+/* Override hover for coverage-typed rows to use same neutral grey */
+table.source tr.coverNone:hover td.line,
+table.source tr.coverNone:hover td.hits,
+table.source tr.coverNone:hover td.code {
+    background: rgb(239, 242, 249) !important;
+}
+
+table.source tr.coverFull:hover td.line,
+table.source tr.coverFull:hover td.hits,
+table.source tr.coverFull:hover td.code {
+    background: rgb(239, 242, 249) !important;
+}
+
+table.source tr.coverPart:hover td.line,
+table.source tr.coverPart:hover td.hits,
+table.source tr.coverPart:hover td.code {
+    background: rgb(239, 242, 249) !important;
+}
+
+/* --- Hits column: position:relative so ::after stripe is positioned correctly --- */
+table.source tr td.hits {
+    position: relative;
+    padding-right: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: right;
+    min-height: 23px;
+}
+
+/* td.code needs position:relative for the ::after overlay pseudo-element */
+table.source tr td.code {
+    position: relative;
+}
+
+/* --- 5px colored stripe on the right edge of the hits column --- */
+table.source tr td.hits:after {
+    content: "";
+    position: absolute;
+    right: -1px;
+    display: inline-block;
+    width: 5px;
+    height: 23px;
+}
+
+/* Green stripe for fully covered lines */
+table.source tr.coverFull td.hits:after {
+    background-color: rgb(166, 244, 197);
+}
+
+/* Red stripe for uncovered lines */
+table.source tr.coverNone td.hits:after {
+    background-color: rgb(217, 45, 32);
+}
+
+/* Orange stripe for partially covered lines */
+table.source tr.coverPart td.hits:after {
+    background-color: rgb(255, 165, 0);
+}
+
+/* Ensure line/hits columns for uncovered rows keep default background */
+table.source tr.coverNone td.line {
+    background-color: var(--background-color) !important;
+}
+
+table.source tr.coverNone td.hits {
+    background-color: var(--background-color) !important;
+}
+
+/* --- Skipped lines --- */
 table.source tr.coverSkip {
-    background-color: #b4b4b4;
+    background-color: #b4b4b4 !important;
+}
+
+/* Hide tippy tooltips (replaced by our own block labels) */
+div[id^=tippy] {
+    display: none !important;
 }

--- a/plugin/src/main/webapp/css/view-model.css
+++ b/plugin/src/main/webapp/css/view-model.css
@@ -531,10 +531,3 @@ table.source tr.coverNone td.hits {
 table.source tr.coverSkip {
     background-color: #b4b4b4 !important;
 }
-
-/*
- * Suppress tippy tooltip popups for mutation coverage tables only.
- */
-table.source:has(tr.mutation) [data-html-tooltip] {
-    pointer-events: none;
-}

--- a/plugin/src/main/webapp/css/view-model.css
+++ b/plugin/src/main/webapp/css/view-model.css
@@ -147,6 +147,13 @@ table.source tr td {
 }
 
 /*
+ * Sentinel row emitted by MutationSourcePrinter.getColumnHeader(). It is invisible to the user but lets :has(tr.mutation) * CSS selectors identify mutation coverage tables and override block label text.
+ */
+table.source tr.mutation {
+    display: none;
+}
+
+/*
  * "New Code" label appears above the FIRST row of a modified block.
  * It is always visible (not hover-dependent) so users immediately know
  * which lines are new/changed since the reference build.
@@ -203,6 +210,14 @@ table.source tr:has(~ tr.coverNone:hover) ~ tr:not(.coverNone) + tr.coverNone:af
     align-items: center;
     font-family: monospace;
     z-index: 2;
+}
+
+/*
+ * Mutation coverage override: for tables that contain the .mutation sentinel row,
+ * replace "Uncovered code" with "Mutations survived" — the correct mutation context label.
+ */
+table.source:has(tr.mutation) tr:has(~ tr.coverNone:hover) ~ tr:not(.coverNone) + tr.coverNone:after {
+    content: "Mutations survived";
 }
 
 /* Highlight subsequent uncovered lines after the hovered uncovered line. */
@@ -284,6 +299,13 @@ table.source tr:has(~ tr.coverFull:hover) ~ tr:not(.coverFull) + tr.coverFull:af
     z-index: 2;
 }
 
+/*
+ * Mutation coverage override: replace "Covered code" with "All mutations killed".
+ */
+table.source:has(tr.mutation) tr:has(~ tr.coverFull:hover) ~ tr:not(.coverFull) + tr.coverFull:after {
+    content: "All mutations killed";
+}
+
 /* Highlight subsequent covered lines after the hovered covered line. */
 table.source tr.coverFull:hover ~ tr.coverFull td.code:after {
     content: "";
@@ -362,6 +384,13 @@ table.source tr:has(~ tr.coverPart:hover) ~ tr:not(.coverPart) + tr.coverPart:af
     align-items: center;
     font-family: monospace;
     z-index: 2;
+}
+
+/*
+ * Mutation coverage override: replace "Partially covered code" with "Some mutations survived".
+ */
+table.source:has(tr.mutation) tr:has(~ tr.coverPart:hover) ~ tr:not(.coverPart) + tr.coverPart:after {
+    content: "Some mutations survived";
 }
 
 /* Highlight subsequent partially covered lines after the hovered line. */
@@ -501,4 +530,11 @@ table.source tr.coverNone td.hits {
 /* --- Skipped lines --- */
 table.source tr.coverSkip {
     background-color: #b4b4b4 !important;
+}
+
+/*
+ * Suppress tippy tooltip popups for mutation coverage tables only.
+ */
+table.source:has(tr.mutation) [data-html-tooltip] {
+    pointer-events: none;
 }

--- a/plugin/src/main/webapp/css/view-model.css
+++ b/plugin/src/main/webapp/css/view-model.css
@@ -502,8 +502,3 @@ table.source tr.coverNone td.hits {
 table.source tr.coverSkip {
     background-color: #b4b4b4 !important;
 }
-
-/* Hide tippy tooltips (replaced by our own block labels) */
-div[id^=tippy] {
-    display: none !important;
-}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
@@ -105,7 +105,7 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
                 .nodesByXPath("/tr").exist().hasSize(1)
                 .singleElement()
                 .hasAttribute(CLASS, CoverageSourcePrinter.NO_COVERAGE)
-                .hasAttribute("data-html-tooltip", "Not covered");
+                .doesNotHaveAttribute("data-html-tooltip");
         var assertThatColumns = XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td").exist().hasSize(3);
         assertThatColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
 

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
@@ -15,7 +15,6 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
     static final String RENDERED_CODE = "\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0"
             + "for\u00a0(int\u00a0line\u00a0=\u00a00;\u00a0line\u00a0<\u00a0lines.size();\u00a0line++)\u00a0{";
 
-
     @Test
     void shouldRenderLinesWithVariousCoverages() {
         var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
@@ -12,8 +12,9 @@ import static org.assertj.core.api.Assertions.*;
 
 class CoverageSourcePrinterTest extends AbstractCoverageTest {
     static final String CLASS = "class";
-    static final String RENDERED_CODE = "                    "
-            + "for (int line = 0; line < lines.size(); line++) {";
+    static final String RENDERED_CODE = "\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0"
+            + "for\u00a0(int\u00a0line\u00a0=\u00a00;\u00a0line\u00a0<\u00a0lines.size();\u00a0line++)\u00a0{";
+
 
     @Test
     void shouldRenderLinesWithVariousCoverages() {
@@ -82,7 +83,7 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
     }
 
     @Test
-    void shouldRenderNoBrnachCoverage() {
+    void shouldRenderNoBranchCoverage() {
         var tree = readResult("../steps/jacoco-analysis-model.xml", new JacocoParser());
 
         var file = new CoverageSourcePrinter(tree.findFile("LineRangeList.java").get());
@@ -132,7 +133,7 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
         XmlAssert.assertThat(skippedLine).nodesByXPath("/tr/td[2]")
                 .extractingText().containsExactly(StringUtils.EMPTY);
         XmlAssert.assertThat(skippedLine).nodesByXPath("/tr/td[3]")
-                .extractingText().containsExactly("package io.jenkins.plugins.coverage.metrics.source;");
+                .extractingText().containsExactly("package\u00a0io.jenkins.plugins.coverage.metrics.source;");
     }
 
     @Test
@@ -141,5 +142,209 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
 
         assertThat(printer.cleanupCode("#include <string>")).isEqualTo("#include&nbsp;&lt;string&gt;");
         assertThat(printer.cleanupCode("int a; int *p = &a;")).isEqualTo("int&nbsp;a;&nbsp;int&nbsp;*p&nbsp;=&nbsp;&amp;a;");
+    }
+
+    @Test
+    void shouldHaveCorrectCssClassConstants() {
+        assertThat(CoverageSourcePrinter.FULL_COVERAGE).isEqualTo("coverFull");
+        assertThat(CoverageSourcePrinter.PARTIAL_COVERAGE).isEqualTo("coverPart");
+        assertThat(CoverageSourcePrinter.NO_COVERAGE).isEqualTo("coverNone");
+        assertThat(CoverageSourcePrinter.UNDEFINED).isEqualTo("noCover");
+        assertThat(CoverageSourcePrinter.MODIFIED).isEqualTo("modified");
+    }
+
+    @Test
+    void shouldRenderTdClassesRequiredByCssOverlays() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var node = tree.findFile("TreeStringBuilder.java").get();
+        node.addModifiedLines(19, 61);
+        var file = new CoverageSourcePrinter(node);
+
+        var coverFull = file.renderLine(19, "// covered\n");
+        var fullColumns = XmlAssert.assertThat(coverFull).nodesByXPath("/tr/td").exist().hasSize(3);
+        fullColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
+
+        var coverNone = file.renderLine(61, "// uncovered\n");
+        var noneColumns = XmlAssert.assertThat(coverNone).nodesByXPath("/tr/td").exist().hasSize(3);
+        noneColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
+
+        var coverPart = file.renderLine(113, "// partial\n");
+        var partColumns = XmlAssert.assertThat(coverPart).nodesByXPath("/tr/td").exist().hasSize(3);
+        partColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
+
+        var noCover = file.renderLine(1, "package x;\n");
+        var noCoverColumns = XmlAssert.assertThat(noCover).nodesByXPath("/tr/td").exist().hasSize(3);
+        noCoverColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
+    }
+
+    @Test
+    void shouldRenderModifiedClassOnConsecutiveLines() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var node = tree.findFile("TreeStringBuilder.java").get();
+
+        node.addModifiedLines(61, 0);
+        var file = new CoverageSourcePrinter(node);
+
+        var modLine61 = file.renderLine(61, "int x = 0;\n");
+        XmlAssert.assertThat(modLine61)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.NO_COVERAGE + " " + CoverageSourcePrinter.MODIFIED);
+
+        var modLine0 = file.renderLine(0, "int x = 0;\n");
+        XmlAssert.assertThat(modLine0)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.UNDEFINED + " " + CoverageSourcePrinter.MODIFIED);
+
+        var unmodLine19 = file.renderLine(19, "return true;\n");
+        XmlAssert.assertThat(unmodLine19)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.FULL_COVERAGE);
+        
+        XmlAssert.assertThat(unmodLine19)
+                .nodesByXPath("/tr/@class").exist()
+                .extractingText()
+                .containsExactly(CoverageSourcePrinter.FULL_COVERAGE);
+
+        var unmodLine113 = file.renderLine(113, "return x;\n");
+        XmlAssert.assertThat(unmodLine113)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.PARTIAL_COVERAGE);
+        XmlAssert.assertThat(unmodLine113)
+                .nodesByXPath("/tr/@class").exist()
+                .extractingText()
+                .containsExactly(CoverageSourcePrinter.PARTIAL_COVERAGE);
+    }
+
+    @Test
+    void shouldRenderUndefinedClassForUnpaintedLine() {
+        var printer = new CoverageSourcePrinter(new FileNode("Test.java", "src/Test.java"));
+
+        var rendered = printer.renderLine(42, "// no coverage data");
+
+        XmlAssert.assertThat(rendered)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.UNDEFINED)
+                .doesNotHaveAttribute("data-html-tooltip");
+    }
+
+    @Test
+    void shouldNotRenderModifiedClassForUnmodifiedLine() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var file = new CoverageSourcePrinter(tree.findFile("TreeStringBuilder.java").get());
+
+        var rendered = file.renderLine(61,
+                "                    for (int line = 0; line < lines.size(); line++) {\n");
+
+        XmlAssert.assertThat(rendered)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS, CoverageSourcePrinter.NO_COVERAGE);
+
+        assertThat(rendered).doesNotContain("modified");
+    }
+
+    @Test
+    void shouldReturnCorrectModifiedClassString() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var node = tree.findFile("TreeStringBuilder.java").get();
+        node.addModifiedLines(19, 61);
+        var file = new CoverageSourcePrinter(node);
+
+        assertThat(file.getModifiedClass(19)).isEqualTo(CoverageSourcePrinter.MODIFIED);
+        assertThat(file.getModifiedClass(61)).isEqualTo(CoverageSourcePrinter.MODIFIED);
+        assertThat(file.getModifiedClass(113)).isEqualTo(StringUtils.EMPTY);
+        assertThat(file.getModifiedClass(0)).isEqualTo(StringUtils.EMPTY);
+    }
+
+    @Test
+    void shouldRenderAllModifiedCoverageClassCombinations() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var node = tree.findFile("TreeStringBuilder.java").get();
+
+        node.addModifiedLines(19, 61, 113, 1);
+        var file = new CoverageSourcePrinter(node);
+
+        var sourceSnippet = "// some code\n";
+
+        XmlAssert.assertThat(file.renderLine(19, sourceSnippet))
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS,
+                        CoverageSourcePrinter.FULL_COVERAGE + " " + CoverageSourcePrinter.MODIFIED);
+
+        XmlAssert.assertThat(file.renderLine(61, sourceSnippet))
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS,
+                        CoverageSourcePrinter.NO_COVERAGE + " " + CoverageSourcePrinter.MODIFIED);
+
+        XmlAssert.assertThat(file.renderLine(113, sourceSnippet))
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS,
+                        CoverageSourcePrinter.PARTIAL_COVERAGE + " " + CoverageSourcePrinter.MODIFIED);
+
+        XmlAssert.assertThat(file.renderLine(1, sourceSnippet))
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CLASS,
+                        CoverageSourcePrinter.UNDEFINED + " " + CoverageSourcePrinter.MODIFIED);
+    }
+
+    @Test
+    void shouldRenderBranchCoverageTooltips() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var file = new CoverageSourcePrinter(tree.findFile("StringContainsUtils.java").get());
+
+        assertThat(file.getTooltip(43)).isEqualTo("All branches covered");
+        assertThat(file.getSummaryColumn(43)).isEqualTo("2/2");
+        assertThat(file.getColorClass(43)).isEqualTo(CoverageSourcePrinter.FULL_COVERAGE);
+
+        var treeTwo = readResult("../steps/jacoco-analysis-model.xml", new JacocoParser());
+        var fileTwo = new CoverageSourcePrinter(treeTwo.findFile("LineRangeList.java").get());
+
+        assertThat(fileTwo.getTooltip(265)).isEqualTo("No branches covered");
+        assertThat(fileTwo.getSummaryColumn(265)).isEqualTo("0/2");
+        assertThat(fileTwo.getColorClass(265)).isEqualTo(CoverageSourcePrinter.NO_COVERAGE);
+    }
+
+    @Test
+    void shouldReturnEmptyColumnHeader() {
+        var printer = new CoverageSourcePrinter(new FileNode("Test.java", "src/Test.java"));
+
+        assertThat(printer.getColumnHeader()).isEmpty();
+    }
+
+    @Test
+    void shouldReportIsPaintedCorrectly() {
+        var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
+        var file = new CoverageSourcePrinter(tree.findFile("TreeStringBuilder.java").get());
+
+        assertThat(file.isPainted(19)).isTrue();
+        assertThat(file.isPainted(61)).isTrue();
+        assertThat(file.isPainted(113)).isTrue();
+
+        assertThat(file.isPainted(1)).isFalse();
+    }
+
+    @Test
+    void shouldCleanupCodeForHtmlRendering() {
+        var printer = new CoverageSourcePrinter(new FileNode("Test.java", "src/Test.java"));
+
+        assertThat(printer.cleanupCode("line\n")).isEqualTo("line");
+        assertThat(printer.cleanupCode("line\r\n")).isEqualTo("line");
+
+        assertThat(printer.cleanupCode("a b")).isEqualTo("a&nbsp;b");
+
+        assertThat(printer.cleanupCode("\tcode"))
+                .isEqualTo("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;code");
+
+        assertThat(printer.cleanupCode("<div>")).isEqualTo("&lt;div&gt;");
+        assertThat(printer.cleanupCode("a & b")).isEqualTo("a&nbsp;&amp;&nbsp;b");
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
@@ -10,6 +10,9 @@ import io.jenkins.plugins.coverage.metrics.AbstractCoverageTest;
 import static org.assertj.core.api.Assertions.*;
 
 class MutationSourcePrinterTest extends AbstractCoverageTest {
+    /** CSS class emitted by the sentinel row to identify mutation coverage tables. */
+    static final String MUTATION_CLASS = "mutation";
+
     @Test
     void shouldRenderLinesWithVariousMutations() {
         var tree = readResult("../steps/mutations.xml", new PitestParser());
@@ -114,5 +117,19 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .singleElement()
                 .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.UNDEFINED)
                 .doesNotHaveAttribute("data-html-tooltip");
+    }
+
+    @Test
+    void shouldEmitMutationSentinelRowAsColumnHeader() {
+        var tree = readResult("../steps/mutations.xml", new PitestParser());
+        var file = new MutationSourcePrinter(tree.findFile("CoberturaParser.java").get());
+
+        var header = file.getColumnHeader();
+
+        assertThat(header).isNotEmpty();
+        XmlAssert.assertThat(header)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CoverageSourcePrinterTest.CLASS, MUTATION_CLASS);
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
@@ -49,12 +49,15 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .nodesByXPath("/tr").exist().hasSize(1)
                 .singleElement()
                 .hasAttribute(CoverageSourcePrinterTest.CLASS, "coverNone")
-                .hasAttribute("data-html-tooltip");
+                .doesNotHaveAttribute("data-html-tooltip");
         var assertThatColumns = XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td").exist().hasSize(3);
         assertThatColumns.extractingAttribute("class").containsExactly("line", "hits", "code");
 
         XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td[1]/a").exist().hasSize(1)
                 .extractingAttribute("name").containsExactly("137");
+        XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td[2]").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute("data-html-tooltip");
         XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td[2]")
                 .extractingText().containsExactly("0/1");
         XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td[3]")
@@ -62,7 +65,7 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
     }
 
     @Test
-    void shouldRenderDataHtmlTooltipOnAllMutationPaintedLines() {
+    void shouldRenderDataHtmlTooltipOnHitsCellForAllMutationPaintedLines() {
         var tree = readResult("../steps/mutations.xml", new PitestParser());
         var file = new MutationSourcePrinter(tree.findFile("CoberturaParser.java").get());
 
@@ -73,9 +76,13 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .nodesByXPath("/tr").exist().hasSize(1)
                 .singleElement()
                 .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.FULL_COVERAGE)
+                .doesNotHaveAttribute("data-html-tooltip");
+        XmlAssert.assertThat(fullLine)
+                .nodesByXPath("/tr/td[2]").exist().hasSize(1)
+                .singleElement()
                 .hasAttribute("data-html-tooltip");
         XmlAssert.assertThat(fullLine)
-                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .nodesByXPath("/tr/td[2]/@data-html-tooltip").exist()
                 .extractingText().first().asString()
                 .contains("Killed Mutations:");
 
@@ -84,9 +91,13 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .nodesByXPath("/tr").exist().hasSize(1)
                 .singleElement()
                 .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.NO_COVERAGE)
+                .doesNotHaveAttribute("data-html-tooltip");
+        XmlAssert.assertThat(survivedLine)
+                .nodesByXPath("/tr/td[2]").exist().hasSize(1)
+                .singleElement()
                 .hasAttribute("data-html-tooltip");
         XmlAssert.assertThat(survivedLine)
-                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .nodesByXPath("/tr/td[2]/@data-html-tooltip").exist()
                 .extractingText().first().asString()
                 .contains("Survived Mutations:");
 
@@ -95,16 +106,21 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .nodesByXPath("/tr").exist().hasSize(1)
                 .singleElement()
                 .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.PARTIAL_COVERAGE)
+                .doesNotHaveAttribute("data-html-tooltip");
+        XmlAssert.assertThat(partialLine)
+                .nodesByXPath("/tr/td[2]").exist().hasSize(1)
+                .singleElement()
                 .hasAttribute("data-html-tooltip");
         XmlAssert.assertThat(partialLine)
-                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .nodesByXPath("/tr/td[2]/@data-html-tooltip").exist()
                 .extractingText().first().asString()
                 .contains("Killed Mutations:");
         XmlAssert.assertThat(partialLine)
-                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .nodesByXPath("/tr/td[2]/@data-html-tooltip").exist()
                 .extractingText().first().asString()
                 .contains("Survived Mutations:");
     }
+
 
     @Test
     void shouldNotRenderTooltipOnUnpaintedMutationLines() {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
@@ -121,7 +121,6 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
                 .contains("Survived Mutations:");
     }
 
-
     @Test
     void shouldNotRenderTooltipOnUnpaintedMutationLines() {
         var tree = readResult("../steps/mutations.xml", new PitestParser());

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/MutationSourcePrinterTest.java
@@ -57,4 +57,62 @@ class MutationSourcePrinterTest extends AbstractCoverageTest {
         XmlAssert.assertThat(renderedLine).nodesByXPath("/tr/td[3]")
                 .extractingText().containsExactly(CoverageSourcePrinterTest.RENDERED_CODE);
     }
+
+    @Test
+    void shouldRenderDataHtmlTooltipOnAllMutationPaintedLines() {
+        var tree = readResult("../steps/mutations.xml", new PitestParser());
+        var file = new MutationSourcePrinter(tree.findFile("CoberturaParser.java").get());
+
+        var sourceSnippet = "return value;\n";
+
+        var fullLine = file.renderLine(131, sourceSnippet);
+        XmlAssert.assertThat(fullLine)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.FULL_COVERAGE)
+                .hasAttribute("data-html-tooltip");
+        XmlAssert.assertThat(fullLine)
+                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .extractingText().first().asString()
+                .contains("Killed Mutations:");
+
+        var survivedLine = file.renderLine(137, sourceSnippet);
+        XmlAssert.assertThat(survivedLine)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.NO_COVERAGE)
+                .hasAttribute("data-html-tooltip");
+        XmlAssert.assertThat(survivedLine)
+                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .extractingText().first().asString()
+                .contains("Survived Mutations:");
+
+        var partialLine = file.renderLine(251, sourceSnippet);
+        XmlAssert.assertThat(partialLine)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.PARTIAL_COVERAGE)
+                .hasAttribute("data-html-tooltip");
+        XmlAssert.assertThat(partialLine)
+                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .extractingText().first().asString()
+                .contains("Killed Mutations:");
+        XmlAssert.assertThat(partialLine)
+                .nodesByXPath("/tr/@data-html-tooltip").exist()
+                .extractingText().first().asString()
+                .contains("Survived Mutations:");
+    }
+
+    @Test
+    void shouldNotRenderTooltipOnUnpaintedMutationLines() {
+        var tree = readResult("../steps/mutations.xml", new PitestParser());
+        var file = new MutationSourcePrinter(tree.findFile("CoberturaParser.java").get());
+
+        var unpaintedLine = file.renderLine(1, "package edu.hm.hafner.coverage;\n");
+        XmlAssert.assertThat(unpaintedLine)
+                .nodesByXPath("/tr").exist().hasSize(1)
+                .singleElement()
+                .hasAttribute(CoverageSourcePrinterTest.CLASS, CoverageSourcePrinter.UNDEFINED)
+                .doesNotHaveAttribute("data-html-tooltip");
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
@@ -36,8 +36,8 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 abstract class SourceCodeITest extends AbstractCoverageITest {
-    private static final String ACU_COBOL_PARSER = "<tr class=\"coverFull\" data-html-tooltip=\"Covered at least once\"><td class=\"line\"><a name=\"27\">27</a></td><td class=\"hits\">1</td><td class=\"code\">        super(ACU_COBOL_WARNING_PATTERN);</td></tr>";
-    private static final String PATH_UTIL = "<tr class=\"coverFull\" data-html-tooltip=\"Covered at least once\"><td class=\"line\"><a name=\"20\">20</a></td><td class=\"hits\">1</td><td class=\"code\">public class PathUtil {<!-- --></td></tr>";
+    private static final String ACU_COBOL_PARSER = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"27\">27</a></td><td class=\"hits\">1</td><td class=\"code\">        super(ACU_COBOL_WARNING_PATTERN);</td></tr>";
+    private static final String PATH_UTIL = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"20\">20</a></td><td class=\"hits\">1</td><td class=\"code\">public class PathUtil {<!-- --></td></tr>";
     private static final String NO_SOURCE_CODE = "N/A";
     static final String ACU_COBOL_PARSER_FILE_NAME = "AcuCobolParser.java";
     static final String ACU_COBOL_PARSER_SOURCE_FILE = ACU_COBOL_PARSER_FILE_NAME + ".txt";

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
@@ -36,8 +36,8 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 abstract class SourceCodeITest extends AbstractCoverageITest {
-    private static final String ACU_COBOL_PARSER = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"27\">27</a></td><td class=\"hits\">1</td><td class=\"code\">        super(ACU_COBOL_WARNING_PATTERN);</td></tr>";
-    private static final String PATH_UTIL = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"20\">20</a></td><td class=\"hits\">1</td><td class=\"code\">public class PathUtil {<!-- --></td></tr>";
+    private static final String ACU_COBOL_PARSER = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"27\">27</a></td><td class=\"hits\">1</td><td class=\"code\">\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0super(ACU_COBOL_WARNING_PATTERN);</td></tr>";
+    private static final String PATH_UTIL = "<tr class=\"coverFull\"><td class=\"line\"><a name=\"20\">20</a></td><td class=\"hits\">1</td><td class=\"code\">public\u00a0class\u00a0PathUtil\u00a0{<!-- --></td></tr>";
     private static final String NO_SOURCE_CODE = "N/A";
     static final String ACU_COBOL_PARSER_FILE_NAME = "AcuCobolParser.java";
     static final String ACU_COBOL_PARSER_SOURCE_FILE = ACU_COBOL_PARSER_FILE_NAME + ".txt";


### PR DESCRIPTION
Modernize the layout of the coverage source code view

Fixes #645 

<img width="1096" height="185" alt="Bildschirmfoto 2026-08-25 um 21 17 46" src="https://github.com/user-attachments/assets/d64b8b78-16ab-43bd-ae77-25598e49d462" />
<img width="1099" height="272" alt="Bildschirmfoto 2026-08-25 um 21 17 17" src="https://github.com/user-attachments/assets/227aaef9-4c5f-4f5d-a64e-cc2178492af7" />

