### PR TITLE
Use properties of `ChecksInfo` context when available

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageChecksPublisher.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.LineRange;
 import edu.hm.hafner.util.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,6 +37,7 @@ import io.jenkins.plugins.checks.api.ChecksDetails.ChecksDetailsBuilder;
 import io.jenkins.plugins.checks.api.ChecksOutput.ChecksOutputBuilder;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.coverage.metrics.model.Baseline;
 import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
 import io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder.ChecksAnnotationScope;
@@ -47,7 +49,7 @@ import io.jenkins.plugins.util.QualityGateStatus;
  *
  * @author Florian Orendi
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity"})
 class CoverageChecksPublisher {
     private static final ElementFormatter FORMATTER = new ElementFormatter();
     private static final int TITLE_HEADER_LEVEL = 4;
@@ -57,19 +59,22 @@ class CoverageChecksPublisher {
 
     private final CoverageBuildAction action;
     private final Node rootNode;
+    @CheckForNull
+    private final ChecksInfo checksInfo;
     private final JenkinsFacade jenkinsFacade;
     private final String checksName;
     private final ChecksAnnotationScope annotationScope;
 
     CoverageChecksPublisher(final CoverageBuildAction action, final Node rootNode, final String checksName,
-            final ChecksAnnotationScope annotationScope) {
-        this(action, rootNode, checksName, annotationScope, new JenkinsFacade());
+            final ChecksAnnotationScope annotationScope, @CheckForNull final ChecksInfo checksInfo) {
+        this(action, rootNode, checksName, annotationScope, checksInfo, new JenkinsFacade());
     }
 
     @VisibleForTesting
     CoverageChecksPublisher(final CoverageBuildAction action, final Node rootNode, final String checksName,
-            final ChecksAnnotationScope annotationScope, final JenkinsFacade jenkinsFacade) {
+            final ChecksAnnotationScope annotationScope, @CheckForNull final ChecksInfo checksInfo, final JenkinsFacade jenkinsFacade) {
         this.rootNode = rootNode;
+        this.checksInfo = checksInfo;
         this.jenkinsFacade = jenkinsFacade;
         this.action = action;
         this.checksName = checksName;
@@ -103,11 +108,18 @@ class CoverageChecksPublisher {
                 .withAnnotations(getAnnotations())
                 .build();
 
+        var actualChecksName = Optional.ofNullable(checksInfo).map(ChecksInfo::getName)
+                .filter(StringUtils::isNotEmpty)
+                .orElse(checksName);
+        var detailsUrl = Optional.ofNullable(checksInfo).map(ChecksInfo::getDetailsURL)
+                .filter(StringUtils::isNotEmpty)
+                .orElse(getBaseUrl());
+
         return new ChecksDetailsBuilder()
-                .withName(checksName)
+                .withName(actualChecksName)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(getCheckConclusion(action.getQualityGateResult().getOverallStatus()))
-                .withDetailsURL(getBaseUrl())
+                .withDetailsURL(detailsUrl)
                 .withOutput(output)
                 .build();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -76,7 +76,7 @@ import io.jenkins.plugins.util.ValidationUtilities;
  *
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
+@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects", "PMD.TooManyFields", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public class CoverageRecorder extends Recorder {
     static final String CHECKS_DEFAULT_NAME = "Code Coverage";
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.PackageNode;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.TreeStringBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.IOException;
@@ -51,6 +52,7 @@ import hudson.util.FormValidation.Kind;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.coverage.metrics.steps.CoverageTool.Parser;
 import io.jenkins.plugins.coverage.metrics.steps.CoverageTool.ParserType;
 import io.jenkins.plugins.prism.SourceCodeDirectory;
@@ -98,6 +100,8 @@ public class CoverageRecorder extends Recorder {
     private String sourceCodeEncoding = StringUtils.EMPTY;
     private Set<SourceCodeDirectory> sourceDirectories = new HashSet<>();
     private SourceCodeRetention sourceCodeRetention = SourceCodeRetention.LAST_BUILD;
+    @CheckForNull
+    private ChecksInfo checksInfo;
 
     /**
      * Creates a new instance of {@link  CoverageRecorder}.
@@ -432,7 +436,7 @@ public class CoverageRecorder extends Recorder {
                     getSourceCodeEncoding(), getSourceCodeRetention(), resultHandler, log);
 
             if (!skipPublishingChecks) {
-                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(), getChecksAnnotationScope());
+                var checksPublisher = new CoverageChecksPublisher(action, aggregatedResult, getChecksName(), getChecksAnnotationScope(), checksInfo);
                 checksPublisher.publishCoverageReport(taskListener);
             }
         }
@@ -612,6 +616,10 @@ public class CoverageRecorder extends Recorder {
     @Override
     public Descriptor getDescriptor() {
         return (Descriptor) super.getDescriptor();
+    }
+
+    void setChecksInfo(@CheckForNull final ChecksInfo checksInfo) {
+        this.checksInfo = checksInfo;
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
@@ -36,6 +36,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.prism.SourceCodeDirectory;
 import io.jenkins.plugins.prism.SourceCodeRetention;
 import io.jenkins.plugins.util.AbstractExecution;
@@ -365,6 +366,7 @@ public class CoverageStep extends Step implements Serializable {
             recorder.setSourceCodeEncoding(step.getSourceCodeEncoding());
             recorder.setSourceDirectories(List.copyOf(step.getSourceDirectories()));
             recorder.setSourceCodeRetention(step.getSourceCodeRetention());
+            recorder.setChecksInfo(getContext().get(ChecksInfo.class));
 
             recorder.perform(getRun(), getWorkspace(), getTaskListener(), createResultHandler());
 

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageChecksPublisherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageChecksPublisherTest.java
@@ -22,6 +22,7 @@ import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksOutput;
 import io.jenkins.plugins.checks.api.ChecksStatus;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.coverage.metrics.AbstractCoverageTest;
 import io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder.ChecksAnnotationScope;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -37,6 +38,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
     static final String COVERAGE_ID = "coverage";
     static final String REPORT_NAME = "Name";
     static final int ANNOTATIONS_COUNT_FOR_MODIFIED = 3;
+    static final ChecksInfo NO_CHECKS_INFO = null;
 
     @Test
     void shouldShowQualityGateDetails() {
@@ -44,7 +46,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result,
                 CoverageQualityGateEvaluatorTest.createQualityGateResult()), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 
@@ -64,11 +66,29 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
     }
 
     @Test
+    void shouldShowChecksInfo() {
+        var result = readJacocoResult("jacoco-codingstyle.xml");
+
+        var checksInfo = mock(ChecksInfo.class);
+        var url = "URL";
+        when(checksInfo.getDetailsURL()).thenReturn(url);
+        var name = "name";
+        when(checksInfo.getName()).thenReturn(name);
+
+        var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result), result, REPORT_NAME,
+                ChecksAnnotationScope.SKIP, checksInfo, createJenkins());
+
+        var checkDetails = publisher.extractChecksDetails();
+        assertThat(checkDetails.getName()).contains(name);
+        assertThat(checkDetails.getDetailsURL()).contains(url);
+    }
+
+    @Test
     void shouldShowProjectBaselineForJaCoCo() {
         var result = readJacocoResult("jacoco-codingstyle.xml");
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         assertThatTitleIs(publisher, "Line Coverage: 91.02%, Branch Coverage: 93.97%");
     }
@@ -78,7 +98,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readResult("mutations.xml", new PitestParser());
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         assertThatTitleIs(publisher, "Line Coverage: 93.84%, Mutation Coverage: 90.24%");
     }
@@ -89,7 +109,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readResult("mutations.xml", new PitestParser());
 
         var publisher = new CoverageChecksPublisher(createCoverageBuildAction(result), result, REPORT_NAME,
-                scope, createJenkins());
+                scope, NO_CHECKS_INFO, createJenkins());
 
         assertThat(publisher.extractChecksDetails().getOutput()).isPresent().get().satisfies(output -> {
             assertSummary(output, "coverage-publisher-summary.checks-expected-result-pit");
@@ -102,7 +122,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readResult("mutations.xml", new PitestParser());
 
         var publisher = new CoverageChecksPublisher(createCoverageBuildAction(result), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 
@@ -151,7 +171,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readJacocoResult("jacoco-codingstyle.xml");
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 
@@ -173,7 +193,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readJacocoResult("jacoco-codingstyle.xml");
 
         var publisher = new CoverageChecksPublisher(createCoverageBuildAction(result), result, REPORT_NAME, scope,
-                createJenkins());
+                NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 
@@ -191,7 +211,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result,
                 CoverageQualityGateEvaluatorTest.createQualityGateResult()), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 
@@ -215,7 +235,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readVectorCastResult("vectorcast-statement-mcdc-fcc.xml");
 
         var publisher = new CoverageChecksPublisher(createActionWithoutDelta(result), result, REPORT_NAME,
-                ChecksAnnotationScope.SKIP, createJenkins());
+                ChecksAnnotationScope.SKIP, NO_CHECKS_INFO, createJenkins());
 
         assertThatTitleIs(publisher, "Line Coverage: 79.93%, Branch Coverage: 66.18%");
     }
@@ -253,7 +273,7 @@ class CoverageChecksPublisherTest extends AbstractCoverageTest {
         var result = readVectorCastResult(inFile);
 
         var publisher = new CoverageChecksPublisher(createCoverageBuildAction(result), result, REPORT_NAME, scope,
-                createJenkins());
+                NO_CHECKS_INFO, createJenkins());
 
         var checkDetails = publisher.extractChecksDetails();
 


### PR DESCRIPTION
GitHub checks can be wrapped into an optional `withChecks` block that contains a custom name and URL. In those cases the default values should be overwritten with the context object values.

Followup to https://github.com/jenkinsci/checks-api-plugin/pull/329
