### PR TITLE
Cleanup should only delete sources of the specific ID

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeFacade.java
@@ -123,8 +123,8 @@ public class SourceCodeFacade {
         return files != null && files.length > 0;
     }
 
-    String getCoverageSourcesDirectory() {
-        return COVERAGE_SOURCES_DIRECTORY;
+    String getCoverageSourcesDirectory(final String id) {
+        return COVERAGE_SOURCES_DIRECTORY + "/" + id;
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/SourceCodePainter.java
@@ -12,10 +12,10 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.io.Serial;
 import java.io.InputStreamReader;
-import java.nio.charset.CodingErrorAction;
+import java.io.Serial;
 import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -92,7 +92,7 @@ public class SourceCodePainter {
 
             sourceCodeFacade.copySourcesToBuildFolder(build, workspace, id, log);
         }
-        sourceCodeRetention.cleanup(build, sourceCodeFacade.getCoverageSourcesDirectory(), log);
+        sourceCodeRetention.cleanup(build, sourceCodeFacade.getCoverageSourcesDirectory(id), log);
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/SourceCodeITest.java
@@ -133,16 +133,16 @@ abstract class SourceCodeITest extends AbstractCoverageITest {
 
         job.setDefinition(createPipelineWithSourceCode(LAST_BUILD, sourceDir));
         Run<?, ?> thirdBuild = buildSuccessfully(job);
-        verifySourceCodeInBuild(sourceDir, thirdBuild, ACU_COBOL_PARSER, PATH_UTIL);
-        verifySourceCodeInBuild(sourceDir, firstBuild, NO_SOURCE_CODE, NO_SOURCE_CODE); // should be still available
-        verifySourceCodeInBuild(sourceDir, secondBuild, NO_SOURCE_CODE, NO_SOURCE_CODE); // should be still available
+        verifySourceCodeInBuild(sourceDir, thirdBuild, ACU_COBOL_PARSER, PATH_UTIL);  // should be still available
+        verifySourceCodeInBuild(sourceDir, secondBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE); // PathUtil should be deleted now
+        verifySourceCodeInBuild(sourceDir, firstBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE); // PathUtil should be deleted now
 
         job.setDefinition(createPipelineWithSourceCode(NEVER, sourceDir));
         Run<?, ?> lastBuild = buildSuccessfully(job);
-        verifySourceCodeInBuild(sourceDir, lastBuild, NO_SOURCE_CODE, NO_SOURCE_CODE);
-        verifySourceCodeInBuild(sourceDir, firstBuild, NO_SOURCE_CODE, NO_SOURCE_CODE); // should be still available
-        verifySourceCodeInBuild(sourceDir, secondBuild, NO_SOURCE_CODE, NO_SOURCE_CODE); // should be still available
-        verifySourceCodeInBuild(sourceDir, thirdBuild, NO_SOURCE_CODE, NO_SOURCE_CODE); // should be still available
+        verifySourceCodeInBuild(sourceDir, lastBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE); // PathUtil should be deleted now
+        verifySourceCodeInBuild(sourceDir, thirdBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE); // PathUtil should be deleted now
+        verifySourceCodeInBuild(sourceDir, firstBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE);
+        verifySourceCodeInBuild(sourceDir, secondBuild, ACU_COBOL_PARSER, NO_SOURCE_CODE);
 
         assertThat(temporaryDirectory.listFiles()).isEqualTo(temporaryFiles);
 
@@ -160,7 +160,7 @@ abstract class SourceCodeITest extends AbstractCoverageITest {
         return createPipelineScript("node ('coverage-agent') {"
                 + "    recordCoverage "
                 + "         tools: [[parser: 'JACOCO', pattern: '" + ACU_COBOL_PARSER_COVERAGE_REPORT + "']], \n"
-                + "         sourceCodeRetention: '" + sourceCodeRetention.name() + "', \n"
+                + "         sourceCodeRetention: 'EVERY_BUILD', \n" // AcuCobol is available in all builds
                 + "         sourceCodeEncoding: 'UTF-8', \n"
                 + "         sourceDirectories: [[path: '" + sourceDirectory + "']]\n"
                 + "    recordCoverage id:'path',  "


### PR DESCRIPTION
Previously, the `recordIssues` step deleted all previous results of all steps but actually only the specific results of the current ID should be deleted.

