### PR TITLE
Add remote API for whole-file coverage of modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,21 @@ Example output:
   ]
 }
 ```
+
+The whole-file (absolute) coverage of the files with coverage relevant changes is provided using the following URL: `https://[jenkins-url]/job/[job-name]/[build-number]/coverage/files/api/json?pretty=true`. Only modified files are reported (to keep the response bounded for large projects); each file lists the coverage metrics that are actually available for it, keyed by metric name.
+
+Example output:
+```json
+{
+  "_class": "io.jenkins.plugins.coverage.metrics.restapi.FileCoverageApi",
+  "files": [
+    {
+      "fullyQualifiedFileName": "io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApi.java",
+      "metrics": {
+        "line": "88.44%",
+        "branch": "82.19%"
+      }
+    }
+  ]
+}
+```

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverage.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverage.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * Model class that describes the whole-file coverage of a single file. The file is identified by its fully qualified
+ * name and each available coverage metric is mapped to its formatted percentage value, e.g. {@code {"line": "88.44%",
+ * "branch": "82.19%"}}. Only metrics that actually have a value for this file are included.
+ */
+@ExportedBean
+public class FileCoverage {
+    private final String fullyQualifiedFileName;
+    private final NavigableMap<String, String> metrics;
+
+    FileCoverage(final String fullyQualifiedFileName, final NavigableMap<String, String> metrics) {
+        this.fullyQualifiedFileName = fullyQualifiedFileName;
+        this.metrics = new TreeMap<>(metrics);
+    }
+
+    @Exported(inline = true)
+    public String getFullyQualifiedFileName() {
+        return fullyQualifiedFileName;
+    }
+
+    @Exported(inline = true)
+    public NavigableMap<String, String> getMetrics() {
+        return metrics;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        var that = (FileCoverage) o;
+        return Objects.equals(getFullyQualifiedFileName(), that.getFullyQualifiedFileName())
+                && Objects.equals(getMetrics(), that.getMetrics());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFullyQualifiedFileName(), getMetrics());
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApi.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApi.java
@@ -1,0 +1,64 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeMap;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
+
+/**
+ * Remote API to list the whole-file coverage of the files with coverage relevant changes. Only modified files are
+ * reported to keep the response bounded: a project with tens of thousands of files would otherwise produce an
+ * unmanageable payload when every file is returned. The whole-file coverage values are preserved, i.e. this returns the
+ * absolute coverage of a modified file rather than only the coverage of its modified lines.
+ */
+@ExportedBean
+public class FileCoverageApi {
+    private static final ElementFormatter FORMATTER = new ElementFormatter();
+
+    private final List<FileCoverage> files;
+
+    FileCoverageApi(final Node node) {
+        files = createListOfFilesWithCoverage(node);
+    }
+
+    @Exported(inline = true, name = "files")
+    public List<FileCoverage> getFiles() {
+        return files;
+    }
+
+    /**
+     * Finds the modified files and their whole-file coverage values in the passed {@link Node} object. Only
+     * {@link Coverage} values recorded directly on each {@link FileNode} (e.g. line, branch, instruction, mutation)
+     * are reported; derived container metrics and non-coverage metrics (complexity, loc, tests) are skipped.
+     *
+     * @param node
+     *         containing the file tree.
+     *
+     * @return a list of {@link FileCoverage} objects, one per file with coverage relevant changes.
+     */
+    private List<FileCoverage> createListOfFilesWithCoverage(final Node node) {
+        var result = new ArrayList<FileCoverage>();
+
+        for (FileNode fileNode : node.filterByModifiedFiles().getAllFileNodes()) {
+            var metrics = new TreeMap<String, String>();
+            for (Value value : fileNode.getValues()) {
+                if (value instanceof Coverage coverage && coverage.isSet()) {
+                    metrics.put(coverage.getMetric().toTagName(), FORMATTER.format(coverage, Locale.ENGLISH));
+                }
+            }
+            result.add(new FileCoverage(fileNode.getRelativePath(), metrics));
+        }
+
+        return result;
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiModel.java
@@ -1,0 +1,43 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import edu.hm.hafner.coverage.Node;
+
+import hudson.model.Api;
+import hudson.model.ModelObject;
+
+import io.jenkins.plugins.coverage.metrics.source.Messages;
+
+/**
+ * Server side model that provides the data for the whole-file coverage results.
+ */
+public class FileCoverageApiModel implements ModelObject {
+    private final Node node;
+
+    /**
+     * Creates a new instance of {@link FileCoverageApiModel}.
+     *
+     * @param node
+     *         {@link Node} object
+     */
+    public FileCoverageApiModel(final Node node) {
+        this.node = node;
+    }
+
+    /**
+     * Gets the remote API for the whole-file coverage results.
+     *
+     * @return the remote API
+     */
+    public Api getApi() {
+        return new Api(new FileCoverageApi(getNode()));
+    }
+
+    public Node getNode() {
+        return node;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.Coverage_Title(getNode().getName());
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModel.java
@@ -48,6 +48,7 @@ import io.jenkins.plugins.coverage.metrics.color.CoverageColorJenkinsId;
 import io.jenkins.plugins.coverage.metrics.model.CoverageStatistics;
 import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
 import io.jenkins.plugins.coverage.metrics.restapi.CoverageApi;
+import io.jenkins.plugins.coverage.metrics.restapi.FileCoverageApiModel;
 import io.jenkins.plugins.coverage.metrics.restapi.ModifiedLinesCoverageApiModel;
 import io.jenkins.plugins.coverage.metrics.source.SourceCodeFacade;
 import io.jenkins.plugins.coverage.metrics.source.SourceViewModel;
@@ -78,6 +79,7 @@ public class CoverageViewModel extends DefaultAsyncTableContentProvider implemen
     private static final String INLINE_SUFFIX = "-inline";
     private static final String INFO_MESSAGES_VIEW_URL = "info";
     private static final String MODIFIED_LINES_API_URL = "modified";
+    private static final String FILE_COVERAGE_API_URL = "files";
 
     private static final ElementFormatter FORMATTER = new ElementFormatter();
     private static final Set<Metric> TREE_METRICS = Set.of(
@@ -513,6 +515,9 @@ public class CoverageViewModel extends DefaultAsyncTableContentProvider implemen
     public Object getDynamic(final String link, final StaplerRequest2 request, final StaplerResponse2 response) {
         if (MODIFIED_LINES_API_URL.equals(link)) {
             return new ModifiedLinesCoverageApiModel(node);
+        }
+        if (FILE_COVERAGE_API_URL.equals(link)) {
+            return new FileCoverageApiModel(node);
         }
         if (INFO_MESSAGES_VIEW_URL.equals(link)) {
             return new MessagesViewModel(getOwner(), Messages.MessagesViewModel_Title(),

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/restapi/CoverageApi/_api.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/restapi/CoverageApi/_api.jelly
@@ -12,6 +12,13 @@
     <dd>
       ${%modified.description}
     </dd>
+
+    <dt>
+      <a href="../files/api">${%files.title}</a>
+    </dt>
+    <dd>
+      ${%files.description}
+    </dd>
   </dl>
 
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/restapi/CoverageApi/_api.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/restapi/CoverageApi/_api.properties
@@ -5,3 +5,7 @@ description=If you are not only interested in the summary of the coverage result
 modified.title=Modified Lines Coverage
 modified.description=The numbers of all modified code lines and their respective \
    line coverage sorted in consecutive line blocks per file.
+
+files.title=Whole-File Coverage of Modified Files
+files.description=The absolute (whole-file) coverage of all files with coverage \
+   relevant changes, keyed by metric name. Only modified files are reported.

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiModelTest.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.ModuleNode;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests {@link FileCoverageApiModel}.
+ */
+class FileCoverageApiModelTest {
+    @Test
+    void shouldExposeApiNodeAndDisplayName() {
+        var node = new ModuleNode("root");
+        var model = new FileCoverageApiModel(node);
+
+        assertThat(model.getNode()).isSameAs(node);
+        assertThat(model.getDisplayName()).isEqualTo("Coverage of 'root'");
+        assertThat(model.getApi()).isNotNull();
+        assertThat(model.getApi().bean).isInstanceOf(FileCoverageApi.class);
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageApiTest.java
@@ -1,0 +1,105 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.PackageNode;
+import edu.hm.hafner.coverage.Value;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.kohsuke.stapler.export.ExportConfig;
+import org.kohsuke.stapler.export.Flavor;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.ModelBuilder;
+
+import io.jenkins.plugins.coverage.metrics.AbstractModifiedFilesCoverageTest;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests {@link FileCoverageApi}.
+ */
+class FileCoverageApiTest extends AbstractModifiedFilesCoverageTest {
+    /**
+     * Verifies that only files with coverage relevant changes are reported, and that their whole-file (absolute)
+     * coverage values are preserved.
+     */
+    @Test
+    void shouldReportWholeFileCoverageOnlyForModifiedFiles() {
+        var files = new FileCoverageApi(createCoverageTree()).getFiles();
+
+        assertThat(files).extracting(FileCoverage::getFullyQualifiedFileName)
+                .containsExactly(getPathOfFileWithModifiedLines());
+        assertThat(files.get(0).getMetrics()).containsKey("line");
+        assertThat(files.get(0).getMetrics().get("line")).matches("\\d+(\\.\\d+)?%");
+    }
+
+    /**
+     * Verifies that the exported bean is serialized by Stapler into a non-empty {@code files} array with the expected
+     * shape.
+     */
+    @Test
+    void shouldExportFilesAsJson() throws IOException {
+        var api = new FileCoverageApi(createCoverageTree());
+
+        var json = exportToJson(api);
+
+        assertThatJson(json).node("files").isArray().isNotEmpty();
+        assertThatJson(json).node("files[0].fullyQualifiedFileName").isEqualTo(getPathOfFileWithModifiedLines());
+        assertThatJson(json).node("files[0].metrics.line").isString();
+    }
+
+    /**
+     * Verifies that all set coverage metrics are reported keyed by their tag name, sorted lexicographically, and that
+     * non-coverage values as well as unset coverage values are skipped.
+     */
+    @Test
+    void shouldReportAllSetCoverageMetrics() {
+        var fileNode = new FileNode("Test.java", "path");
+        fileNode.addModifiedLines(1);
+        fileNode.addCounters(1, 1, 0);
+        fileNode.addValue(new CoverageBuilder().withMetric(Metric.LINE).withCovered(88).withMissed(12).build());
+        fileNode.addValue(new CoverageBuilder().withMetric(Metric.BRANCH).withCovered(9).withMissed(1).build());
+        fileNode.addValue(new CoverageBuilder().withMetric(Metric.INSTRUCTION).withCovered(80).withMissed(20).build());
+        fileNode.addValue(new Value(Metric.LOC, 1000));
+        fileNode.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 150));
+        fileNode.addValue(Coverage.nullObject(Metric.MCDC_PAIR));
+        var parentNode = new PackageNode("package");
+        parentNode.addChild(fileNode);
+
+        var files = new FileCoverageApi(parentNode).getFiles();
+
+        assertThat(files).hasSize(1);
+        var metrics = files.get(0).getMetrics();
+        assertThat(metrics.keySet()).containsExactly("branch", "instruction", "line");
+        assertThat(metrics).doesNotContainKeys("loc", "cyclomatic-complexity", "mcdc-pair");
+        assertThat(metrics.values()).allSatisfy(value -> assertThat(value).matches("\\d+(\\.\\d+)?%"));
+    }
+
+    /**
+     * Verifies that files with modified lines but no covered modified lines are not reported at all.
+     */
+    @Test
+    void shouldReportNothingWhenNoFileHasCoveredModifiedLines() {
+        var fileNode = new FileNode("Test.java", "path");
+        fileNode.addModifiedLines(1);
+        var parentNode = new PackageNode("package");
+        parentNode.addChild(fileNode);
+
+        assertThat(new FileCoverageApi(parentNode).getFiles()).isEmpty();
+    }
+
+    private String exportToJson(final FileCoverageApi api) throws IOException {
+        Model<FileCoverageApi> model = new ModelBuilder().get(FileCoverageApi.class);
+        try (var writer = new StringWriter()) {
+            model.writeTo(api, Flavor.JSON.createDataWriter(api, writer, new ExportConfig()));
+            return writer.toString();
+        }
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/restapi/FileCoverageTest.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.coverage.metrics.restapi;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Tests {@link FileCoverage}.
+ */
+class FileCoverageTest {
+    @Test
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.forClass(FileCoverage.class).usingGetClass().verify();
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageViewModelTest.java
@@ -16,7 +16,9 @@ import java.util.function.Function;
 
 import hudson.model.Run;
 
+import io.jenkins.plugins.bootstrap5.MessagesViewModel;
 import io.jenkins.plugins.coverage.metrics.AbstractCoverageTest;
+import io.jenkins.plugins.coverage.metrics.restapi.FileCoverageApiModel;
 import io.jenkins.plugins.coverage.metrics.steps.CoverageTableModel.CoverageRow;
 import io.jenkins.plugins.util.QualityGateResult;
 
@@ -112,6 +114,14 @@ class CoverageViewModelTest extends AbstractCoverageTest {
 
         assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> model.getTableModel("wrong-id"));
+    }
+
+    @Test
+    void shouldProvideFileCoverageApi() {
+        var model = createModel(createIndirectCoverageChangesNode());
+
+        assertThat(model.getDynamic("files", null, null)).isInstanceOf(FileCoverageApiModel.class);
+        assertThat(model.getDynamic("info", null, null)).isInstanceOf(MessagesViewModel.class);
     }
 
     private CoverageViewModel createModelFromCodingStyleReport() {


### PR DESCRIPTION
Expose the absolute (whole-file) coverage of files with coverage relevant changes via a new REST endpoint /coverage/files/api/json. Only modified files are reported to keep the response bounded for large projects; each file lists its available coverage metrics (line, branch, instruction, …) keyed by metric name.

The endpoint mirrors ModifiedLinesCoverageApi but reports each file's whole-file Coverage values rather than its modified-lines blocks, so consumers can populate per-file absolute coverage columns.

<!-- Please describe your pull request here. -->

### Testing done

Deploy in Amarula Solutions. This is an example of result:

```
{
  "_class": "io.jenkins.plugins.coverage.metrics.restapi.FileCoverageApi",
  "files": [
    {
      "fullyQualifiedFileName": "common/src/commonMain/kotlin/com/amarula/travelsmart/common/ui/effects/TransactionsEffect.kt",
      "metrics": {
        "instruction": "100.00%",
        "line": "100.00%"
      }
    },
    {
      "fullyQualifiedFileName": "common/src/commonMain/kotlin/com/amarula/travelsmart/common/ui/state/v2/TransactionsUiState.kt",
      "metrics": {
        "instruction": "100.00%",
        "line": "100.00%"
      }
    },
    {
      "fullyQualifiedFileName": "common/src/commonMain/kotlin/com/amarula/travelsmart/common/ui/viewmodel/v2/TransactionsViewModel.kt",
      "metrics": {
        "branch": "80.00%",
        "instruction": "98.36%",
        "line": "97.30%"
      }
    },
    {
      "fullyQualifiedFileName": "common/src/commonMain/kotlin/com/amarula/travelsmart/common/di/ViewModelsModule.kt",
      "metrics": {
        "instruction": "0.00%",
        "line": "0.00%"
      }
    },
    {
      "fullyQualifiedFileName": "common/src/commonMain/kotlin/com/amarula/travelsmart/common/ui/screens/timetracking/StatisticsScreen.kt",
      "metrics": {
        "branch": "2.17%",
        "instruction": "0.29%",
        "line": "0.00%"
      }
    }
  ]
}
```

<img width="1852" height="685" alt="image" src="https://github.com/user-attachments/assets/d28924ff-c841-4191-b25e-d08ed087d85a" />

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
